### PR TITLE
feat: cli return rendered usage

### DIFF
--- a/src/__snapshots__/cli.test.ts.snap
+++ b/src/__snapshots__/cli.test.ts.snap
@@ -1,5 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`aute generate usage > inline function > USAGE:
+  COMMAND <OPTIONS> 
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+ 1`] = `
+"USAGE:
+  COMMAND <OPTIONS> 
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
 exports[`aute generate usage > inline function 1`] = `
 "USAGE:
   COMMAND <OPTIONS> 
@@ -29,7 +45,47 @@ EXAMPLES:
 "
 `;
 
+exports[`aute generate usage > loosely entry command > USAGE:
+  COMMAND <OPTIONS> 
+
+OPTIONS:
+  -f, --foo <foo>          
+  -h, --help               Display this help message
+  -v, --version            Display this version
+ 1`] = `
+"USAGE:
+  COMMAND <OPTIONS> 
+
+OPTIONS:
+  -f, --foo <foo>          
+  -h, --help               Display this help message
+  -v, --version            Display this version
+"
+`;
+
 exports[`aute generate usage > loosely entry command 1`] = `
+"USAGE:
+  COMMAND <OPTIONS> 
+
+OPTIONS:
+  -f, --foo <foo>          
+  -h, --help               Display this help message
+  -v, --version            Display this version
+"
+`;
+
+exports[`aute generate usage > loosely sub commands > command2 1`] = `
+"USAGE:
+  COMMAND command2 <OPTIONS>
+
+OPTIONS:
+  -b, --bar [bar]          
+  -h, --help               Display this help message
+  -v, --version            Display this version
+"
+`;
+
+exports[`aute generate usage > loosely sub commands > main 1`] = `
 "USAGE:
   COMMAND <OPTIONS> 
 
@@ -59,7 +115,21 @@ OPTIONS:
 "
 `;
 
-exports[`aute generate usage > strictly entry command 1`] = `
+exports[`aute generate usage > strictly entry command > Modern CLI tool (gunshi v0.0.0)
+USAGE:
+  gunshi <OPTIONS> 
+
+OPTIONS:
+  -f, --foo <foo>          [string]  The foo option
+  -h, --help               [boolean] Display this help message
+  -v, --version            [boolean] Display this version
+
+EXAMPLES:
+  # Example 1
+  $ gunshi --foo bar
+  # Example 2
+  $ gunshi -f bar
+ 1`] = `
 "Modern CLI tool (gunshi v0.0.0)
 
 USAGE:
@@ -75,6 +145,51 @@ EXAMPLES:
   $ gunshi --foo bar
   # Example 2
   $ gunshi -f bar
+"
+`;
+
+exports[`aute generate usage > strictly sub commands > command2 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+USAGE:
+  gunshi command2 <OPTIONS>
+
+OPTIONS:
+  -b, --bar [bar]          The bar option
+  -h, --help               Display this help message
+  -v, --version            Display this version
+
+EXAMPLES:
+  # Example 1
+  $ gunshi command2 --bar 42
+  # Example 2
+  $ gunshi command2 -b 42
+"
+`;
+
+exports[`aute generate usage > strictly sub commands > main 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+使い方:
+    gunshi [command1] <オプション> 
+    gunshi <コマンド>
+
+コマンド:
+    command2                 
+    command1                 
+
+詳細は、コマンドと\`--help\`フラグを実行してください:
+    gunshi command2 --help
+    gunshi command1 --help
+
+オプション:
+    -f, --foo <foo>               The foo option
+    -h, --help                    Display this help message
+    -v, --version                 Display this version
+
+例:
+    # Example 1
+    $ gunshi --foo bar
+    # Example 2
+    $ gunshi -f bar
 "
 `;
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -103,16 +103,17 @@ describe('aute generate usage', () => {
   test('inline function', async () => {
     const utils = await import('./utils')
     const log = defineMockLog(utils)
-    await cli(['-h'], vi.fn())
+    const renderedUsage = await cli(['-h'], vi.fn())
 
     const message = log()
     expect(message).toMatchSnapshot()
+    expect(message).toMatchSnapshot(renderedUsage)
   })
 
   test('loosely entry command', async () => {
     const utils = await import('./utils')
     const log = defineMockLog(utils)
-    await cli(['-h'], {
+    const renderedUsage = await cli(['-h'], {
       options: {
         foo: {
           type: 'string',
@@ -124,12 +125,13 @@ describe('aute generate usage', () => {
 
     const message = log()
     expect(message).toMatchSnapshot()
+    expect(message).toMatchSnapshot(renderedUsage)
   })
 
   test('strictly entry command', async () => {
     const utils = await import('./utils')
     const log = defineMockLog(utils)
-    await cli(
+    const renderedUsage = await cli(
       ['-h'],
       {
         options: {
@@ -156,7 +158,7 @@ describe('aute generate usage', () => {
     )
 
     const message = log()
-    expect(message).toMatchSnapshot()
+    expect(message).toMatchSnapshot(renderedUsage)
   })
 
   test('loosely sub commands', async () => {
@@ -190,8 +192,8 @@ describe('aute generate usage', () => {
     const subCommands = new Map<string, Command<CommandArgs> | LazyCommand<CommandArgs>>()
     subCommands.set('command2', command2)
 
-    await cli(['-h'], entry, { subCommands })
-    await cli(['command2', '-h'], entry, { subCommands })
+    expect(await cli(['-h'], entry, { subCommands })).toMatchSnapshot('main')
+    expect(await cli(['command2', '-h'], entry, { subCommands })).toMatchSnapshot('command2')
 
     const message = log()
     expect(message).toMatchSnapshot()
@@ -244,7 +246,7 @@ describe('aute generate usage', () => {
     const subCommands = new Map()
     subCommands.set('command2', command2)
 
-    await cli(['-h'], entry, {
+    const mainUsageRedered = await cli(['-h'], entry, {
       subCommands,
       name: 'gunshi',
       description: 'Modern CLI tool',
@@ -253,13 +255,15 @@ describe('aute generate usage', () => {
       locale: 'ja-JP',
       middleMargin: 15
     })
+    expect(mainUsageRedered).toMatchSnapshot('main')
 
-    await cli(['command2', '-h'], entry, {
+    const command2UsageRendered = await cli(['command2', '-h'], entry, {
       subCommands,
       name: 'gunshi',
       description: 'Modern CLI tool',
       version: '0.0.0'
     })
+    expect(command2UsageRendered).toMatchSnapshot('command2')
 
     const message = log()
     expect(message).toMatchSnapshot()

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -246,7 +246,7 @@ describe('aute generate usage', () => {
     const subCommands = new Map()
     subCommands.set('command2', command2)
 
-    const mainUsageRedered = await cli(['-h'], entry, {
+    const mainUsageRendered = await cli(['-h'], entry, {
       subCommands,
       name: 'gunshi',
       description: 'Modern CLI tool',
@@ -255,7 +255,7 @@ describe('aute generate usage', () => {
       locale: 'ja-JP',
       middleMargin: 15
     })
-    expect(mainUsageRedered).toMatchSnapshot('main')
+    expect(mainUsageRendered).toMatchSnapshot('main')
 
     const command2UsageRendered = await cli(['command2', '-h'], entry, {
       subCommands,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR will support the returns rendered command usage at the `cli` function.

With this support, we can use it for things like document generation.
By preparing a `renderUsage` that renders markdown and writing a script using it, it is useful for generating documents such as README.md.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
