### PR TITLE
feat: support translation adapter for custom message formatting

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,6 +17,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
   javascript(),
   typescript({
     rules: {
+      '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/ban-ts-comment': 'off'
     }
   }),

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "devDependencies": {
     "@eslint/markdown": "^6.2.2",
+    "@intlify/core": "^11.1.2",
     "@kazupon/eslint-config": "^0.22.0",
     "@kazupon/prettier-config": "^0.1.1",
     "@types/node": "^22.13.9",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "jsr": "^0.13.4",
     "knip": "^5.45.0",
     "lint-staged": "^15.4.3",
+    "messageformat": "4.0.0-9",
     "pkg-pr-new": "^0.0.41",
     "prettier": "^3.5.3",
     "tsdown": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "@eslint/markdown": "^6.2.2",
-    "@intlify/core": "^11.1.2",
+    "@intlify/core": "next",
     "@kazupon/eslint-config": "^0.22.0",
     "@kazupon/prettier-config": "^0.1.1",
     "@types/node": "^22.13.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^6.2.2
         version: 6.2.2
       '@intlify/core':
-        specifier: ^11.1.2
-        version: 11.1.2
+        specifier: next
+        version: 12.0.0-alpha.1
       '@kazupon/eslint-config':
         specifier: ^0.22.0
         version: 0.22.0(@eslint/markdown@6.2.2)(@vitest/eslint-plugin@1.1.36(@typescript-eslint/utils@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)))(eslint-config-prettier@10.0.2(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-jsonc@2.19.1(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-promise@7.2.1(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-regexp@2.7.0(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-unicorn@57.0.0(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-yml@1.17.0(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))(typescript-eslint@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(typescript@5.8.2)
@@ -556,20 +556,20 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
-  '@intlify/core-base@11.1.2':
-    resolution: {integrity: sha512-nmG512G8QOABsserleechwHGZxzKSAlggGf9hQX0nltvSwyKNVuB/4o6iFeG2OnjXK253r8p8eSDOZf8PgFdWw==}
+  '@intlify/core-base@12.0.0-alpha.1':
+    resolution: {integrity: sha512-1H0AKcnN/bqUBtNuMGmFwMJAkVZ1H1KATvoZGChXj46tgIxSEjQW/Es7R/jTewsFwXGQjO2rvxEk1kADFC1G8A==}
     engines: {node: '>= 16'}
 
-  '@intlify/core@11.1.2':
-    resolution: {integrity: sha512-OnBHcGRJbaeGrmBJV4YuK2E0xR7p1nKy1BeVqUqAFv9PQtYuY17cmdEoA3XjwN8HpuE2AsKwWyTmQ3nvFwx+yw==}
+  '@intlify/core@12.0.0-alpha.1':
+    resolution: {integrity: sha512-ZacnCWmzDc2amU4ij9hrE5Ecg1XJueev4i9e62XyDQFUz0xnAL4CPd20HeI1dp3PHaUYrirBnLUCpVyirwq5rg==}
     engines: {node: '>= 16'}
 
-  '@intlify/message-compiler@11.1.2':
-    resolution: {integrity: sha512-T/xbNDzi+Yv0Qn2Dfz2CWCAJiwNgU5d95EhhAEf4YmOgjCKktpfpiUSmLcBvK1CtLpPQ85AMMQk/2NCcXnNj1g==}
+  '@intlify/message-compiler@12.0.0-alpha.1':
+    resolution: {integrity: sha512-rS1Lc99D2uaGqWxlrpGPWdgkq2Jox8xxOS9gdIRhuF2CsuJISWQmwd/TjMnWNhwv9olE0aPEBh1323a61Tfp+g==}
     engines: {node: '>= 16'}
 
-  '@intlify/shared@11.1.2':
-    resolution: {integrity: sha512-dF2iMMy8P9uKVHV/20LA1ulFLL+MKSbfMiixSmn6fpwqzvix38OIc7ebgnFbBqElvghZCW9ACtzKTGKsTGTWGA==}
+  '@intlify/shared@12.0.0-alpha.1':
+    resolution: {integrity: sha512-ZZ5rtlUcEnhhFS+MTrl0V1UoN3yRninGawP3f1YituJN9217xJvpqCSLa9t8NLaVwVIxsRcq4lQe48D0SigmBg==}
     engines: {node: '>= 16'}
 
   '@jridgewell/sourcemap-codec@1.5.0':
@@ -3049,22 +3049,22 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@intlify/core-base@11.1.2':
+  '@intlify/core-base@12.0.0-alpha.1':
     dependencies:
-      '@intlify/message-compiler': 11.1.2
-      '@intlify/shared': 11.1.2
+      '@intlify/message-compiler': 12.0.0-alpha.1
+      '@intlify/shared': 12.0.0-alpha.1
 
-  '@intlify/core@11.1.2':
+  '@intlify/core@12.0.0-alpha.1':
     dependencies:
-      '@intlify/core-base': 11.1.2
-      '@intlify/shared': 11.1.2
+      '@intlify/core-base': 12.0.0-alpha.1
+      '@intlify/shared': 12.0.0-alpha.1
 
-  '@intlify/message-compiler@11.1.2':
+  '@intlify/message-compiler@12.0.0-alpha.1':
     dependencies:
-      '@intlify/shared': 11.1.2
+      '@intlify/shared': 12.0.0-alpha.1
       source-map-js: 1.2.1
 
-  '@intlify/shared@11.1.2': {}
+  '@intlify/shared@12.0.0-alpha.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       lint-staged:
         specifier: ^15.4.3
         version: 15.4.3
+      messageformat:
+        specifier: 4.0.0-9
+        version: 4.0.0-9
       pkg-pr-new:
         specifier: ^0.0.41
         version: 0.0.41
@@ -1956,6 +1959,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  messageformat@4.0.0-9:
+    resolution: {integrity: sha512-4QHEgN5EiK0w8XmMztn+hdnuJuaChp0bv6D1iw1GvFMR9FVDF9sDk0KfIM9XnBjqa0ekK8wBsX7lyMNfD53dqQ==}
 
   micromark-core-commonmark@2.0.2:
     resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
@@ -4416,6 +4422,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  messageformat@4.0.0-9: {}
 
   micromark-core-commonmark@2.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@eslint/markdown':
         specifier: ^6.2.2
         version: 6.2.2
+      '@intlify/core':
+        specifier: ^11.1.2
+        version: 11.1.2
       '@kazupon/eslint-config':
         specifier: ^0.22.0
         version: 0.22.0(@eslint/markdown@6.2.2)(@vitest/eslint-plugin@1.1.36(@typescript-eslint/utils@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0)))(eslint-config-prettier@10.0.2(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-jsonc@2.19.1(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-promise@7.2.1(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-regexp@2.7.0(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-unicorn@57.0.0(eslint@9.21.0(jiti@2.4.2)))(eslint-plugin-yml@1.17.0(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))(typescript-eslint@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(typescript@5.8.2)
@@ -552,6 +555,22 @@ packages:
   '@humanwhocodes/retry@0.4.2':
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
+
+  '@intlify/core-base@11.1.2':
+    resolution: {integrity: sha512-nmG512G8QOABsserleechwHGZxzKSAlggGf9hQX0nltvSwyKNVuB/4o6iFeG2OnjXK253r8p8eSDOZf8PgFdWw==}
+    engines: {node: '>= 16'}
+
+  '@intlify/core@11.1.2':
+    resolution: {integrity: sha512-OnBHcGRJbaeGrmBJV4YuK2E0xR7p1nKy1BeVqUqAFv9PQtYuY17cmdEoA3XjwN8HpuE2AsKwWyTmQ3nvFwx+yw==}
+    engines: {node: '>= 16'}
+
+  '@intlify/message-compiler@11.1.2':
+    resolution: {integrity: sha512-T/xbNDzi+Yv0Qn2Dfz2CWCAJiwNgU5d95EhhAEf4YmOgjCKktpfpiUSmLcBvK1CtLpPQ85AMMQk/2NCcXnNj1g==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.2':
+    resolution: {integrity: sha512-dF2iMMy8P9uKVHV/20LA1ulFLL+MKSbfMiixSmn6fpwqzvix38OIc7ebgnFbBqElvghZCW9ACtzKTGKsTGTWGA==}
+    engines: {node: '>= 16'}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -3029,6 +3048,23 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.2': {}
+
+  '@intlify/core-base@11.1.2':
+    dependencies:
+      '@intlify/message-compiler': 11.1.2
+      '@intlify/shared': 11.1.2
+
+  '@intlify/core@11.1.2':
+    dependencies:
+      '@intlify/core-base': 11.1.2
+      '@intlify/shared': 11.1.2
+
+  '@intlify/message-compiler@11.1.2':
+    dependencies:
+      '@intlify/shared': 11.1.2
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ import type { CommandOptions } from './types'
 export const DEFAULT_LOCALE = 'en-US'
 
 export const BUILT_IN_PREFIX = '_'
+
 export const BUILT_IN_KEY_SEPARATOR = ':'
 
 type CommonOptionType = {
@@ -19,6 +20,7 @@ type CommonOptionType = {
     readonly short: 'v'
   }
 }
+
 export const COMMON_OPTIONS: CommonOptionType = {
   help: {
     type: 'boolean',
@@ -41,7 +43,8 @@ export const COMMAND_OPTIONS_DEFAULT: CommandOptions<ArgOptions> = {
   usageOptionType: false,
   renderHeader: undefined,
   renderUsage: undefined,
-  renderValidationErrors: undefined
+  renderValidationErrors: undefined,
+  translationAdapterFactory: undefined
 }
 
 export const COMMAND_BUILTIN_RESOURCE_KEYS = [

--- a/src/context.ts
+++ b/src/context.ts
@@ -92,7 +92,7 @@ export async function createCommandContext<
   const locale = resolveLocale(commandOptions.locale)
   const translationAdapterFactory =
     commandOptions.translationAdapterFactory || createTranslationAdapter
-  const adapter = translationAdapterFactory({ locale })
+  const adapter = translationAdapterFactory({ fallbackLocale: DEFAULT_LOCALE })
 
   // store built-in locale resources in the environment
   const localeResources: Map<string, Record<string, string>> = new Map()
@@ -134,12 +134,7 @@ export async function createCommandContext<
       // NOTE:
       // for otherwise, if the key is not found in the command resources, then return an empty string.
       // because should not render the key in usage.
-      return adapter.translate(
-        adapter.getMessage(locale.toString(), strKey) ||
-          adapter.getMessage(DEFAULT_LOCALE, strKey) ||
-          '',
-        values
-      )
+      return adapter.translate(locale.toString(), strKey, values) || ''
     }
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -92,7 +92,7 @@ export async function createCommandContext<
   const locale = resolveLocale(commandOptions.locale)
   const translationAdapterFactory =
     commandOptions.translationAdapterFactory || createTranslationAdapter
-  const translation = translationAdapterFactory({ locale })
+  const adapter = translationAdapterFactory({ locale })
 
   // store built-in locale resources in the environment
   const localeResources: Map<string, Record<string, string>> = new Map()
@@ -134,9 +134,9 @@ export async function createCommandContext<
       // NOTE:
       // for otherwise, if the key is not found in the command resources, then return an empty string.
       // because should not render the key in usage.
-      return translation.translate(
-        translation.getMessage(locale.toString(), strKey) ||
-          translation.getMessage(DEFAULT_LOCALE, strKey) ||
+      return adapter.translate(
+        adapter.getMessage(locale.toString(), strKey) ||
+          adapter.getMessage(DEFAULT_LOCALE, strKey) ||
           '',
         values
       )
@@ -196,7 +196,7 @@ export async function createCommandContext<
   }, create<Record<string, string>>())
   defaultCommandResource.description = command.description || ''
   defaultCommandResource.examples = usage.examples || ''
-  translation.setResource(DEFAULT_LOCALE, defaultCommandResource)
+  adapter.setResource(DEFAULT_LOCALE, defaultCommandResource)
 
   const originalResource = await loadCommandResource(ctx, command)
   if (originalResource) {
@@ -212,7 +212,7 @@ export async function createCommandContext<
       resource.help = builtInLoadedResources.help
       resource.version = builtInLoadedResources.version
     }
-    translation.setResource(locale.toString(), resource)
+    adapter.setResource(locale.toString(), resource)
   }
 
   return ctx

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,11 +1,12 @@
 import DefaultResource from '../locales/en-US.json' with { type: 'json' }
 import { BUILT_IN_PREFIX, COMMAND_OPTIONS_DEFAULT, DEFAULT_LOCALE } from './constants.js'
+import { createTranslationAdapter } from './translation.js'
 import { create, deepFreeze, mapResourceWithBuiltinKey, resolveLazyCommand } from './utils.js'
 
 import type { ArgOptions, ArgOptionSchema, ArgValues } from 'args-tokens'
 import type {
   Command,
-  CommandBuiltinResourceKeys,
+  CommandBuiltinKeys,
   CommandContext,
   CommandEnvironment,
   CommandOptions,
@@ -89,11 +90,12 @@ export async function createCommandContext<
   )
 
   const locale = resolveLocale(commandOptions.locale)
+  const translationAdapterFactory =
+    commandOptions.translationAdapterFactory || createTranslationAdapter
+  const translation = translationAdapterFactory({ locale })
 
   // store built-in locale resources in the environment
   const localeResources: Map<string, Record<string, string>> = new Map()
-  // store command resources in sub-commands
-  const commandResources = new Map<string, Record<string, string>>()
 
   let builtInLoadedResources: Record<string, string> | undefined
 
@@ -116,21 +118,28 @@ export async function createCommandContext<
    *
    */
 
-  function translate<T, Key = CommandBuiltinResourceKeys | T>(key: Key): string {
-    if ((key as string).codePointAt(0) === BUILT_IN_PREFIX_CODE) {
+  function translate<
+    T extends string = CommandBuiltinKeys,
+    Key = CommandBuiltinKeys | keyof Options | T
+  >(key: Key, values: Record<string, unknown> = create<Record<string, unknown>>()): string {
+    const strKey = key as string
+    if (strKey.codePointAt(0) === BUILT_IN_PREFIX_CODE) {
       // NOTE:
       // if the key is one of the `COMMAND_BUILTIN_RESOURCE_KEYS` and the key is not found in the locale resources,
       // then return the key itself.
       const resource =
         localeResources.get(locale.toString()) || localeResources.get(DEFAULT_LOCALE)!
-      return resource[key as CommandBuiltinResourceKeys] || (key as string)
+      return resource[strKey as CommandBuiltinKeys] || strKey
     } else {
       // NOTE:
       // for otherwise, if the key is not found in the command resources, then return an empty string.
       // because should not render the key in usage.
-      const resource =
-        commandResources.get(locale.toString()) || commandResources.get(DEFAULT_LOCALE)!
-      return resource[key as string] || ''
+      return translation.translate(
+        translation.getMessage(locale.toString(), strKey) ||
+          translation.getMessage(DEFAULT_LOCALE, strKey) ||
+          '',
+        values
+      )
     }
   }
 
@@ -187,7 +196,7 @@ export async function createCommandContext<
   }, create<Record<string, string>>())
   defaultCommandResource.description = command.description || ''
   defaultCommandResource.examples = usage.examples || ''
-  commandResources.set(DEFAULT_LOCALE, defaultCommandResource)
+  translation.setResource(DEFAULT_LOCALE, defaultCommandResource)
 
   const originalResource = await loadCommandResource(ctx, command)
   if (originalResource) {
@@ -199,21 +208,11 @@ export async function createCommandContext<
       } as Record<string, string>,
       originalResource as Record<string, string>
     )
-    // const resource = Object.entries(originalResource.options).reduce(
-    //   (res, [key, value]) => {
-    //     res[key] = value
-    //     return res
-    //   },
-    //   Object.assign(create<Record<string, string>>(), {
-    //     description: originalResource.description,
-    //     examples: originalResource.examples
-    //   } as Record<string, string>)
-    // )
     if (builtInLoadedResources) {
       resource.help = builtInLoadedResources.help
       resource.version = builtInLoadedResources.version
     }
-    commandResources.set(locale.toString(), resource)
+    translation.setResource(locale.toString(), resource)
   }
 
   return ctx

--- a/src/context.ts
+++ b/src/context.ts
@@ -92,7 +92,10 @@ export async function createCommandContext<
   const locale = resolveLocale(commandOptions.locale)
   const translationAdapterFactory =
     commandOptions.translationAdapterFactory || createTranslationAdapter
-  const adapter = translationAdapterFactory({ fallbackLocale: DEFAULT_LOCALE })
+  const adapter = translationAdapterFactory({
+    locale: locale.toString(),
+    fallbackLocale: DEFAULT_LOCALE
+  })
 
   // store built-in locale resources in the environment
   const localeResources: Map<string, Record<string, string>> = new Map()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export type { ArgOptions, ArgOptionSchema, ArgValues } from 'args-tokens'
 export * from './cli.js'
+export { DefaultTranslation } from './translation.js'
 export type * from './types'

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,0 +1,46 @@
+import { create } from './utils.js'
+
+import type { TranslationAdapter, TranslationAdapterFactoryOptions } from './types'
+
+export function createTranslationAdapter(
+  options: TranslationAdapterFactoryOptions = {}
+): TranslationAdapter {
+  return new DefaultTranslation(options)
+}
+
+export class DefaultTranslation implements TranslationAdapter {
+  #resources: Map<string, Record<string, string>> = new Map()
+
+  constructor(_options: TranslationAdapterFactoryOptions = {}) {
+    this.#resources = new Map()
+  }
+
+  getResource(locale: string): Record<string, string> | undefined {
+    return this.#resources.get(locale)
+  }
+
+  setResource(locale: string, resource: Record<string, string>): void {
+    this.#resources.set(locale, resource)
+  }
+
+  getMessage(locale: string, key: string): string | undefined {
+    const resource = this.getResource(locale)
+    if (resource) {
+      return resource[key]
+    }
+    return undefined
+  }
+
+  translate(
+    message: string,
+    _values: Record<string, unknown> = create<Record<string, unknown>>()
+  ): string {
+    /**
+     * NOTE:
+     * DefaultTranslation support static message only
+     * If you want to resolve message with values and use the complex message format,
+     * you should inherit this class or implement your own translation adapter.
+     */
+    return message
+  }
+}

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -3,15 +3,17 @@ import { create } from './utils.js'
 import type { TranslationAdapter, TranslationAdapterFactoryOptions } from './types'
 
 export function createTranslationAdapter(
-  options: TranslationAdapterFactoryOptions = {}
+  options: TranslationAdapterFactoryOptions
 ): TranslationAdapter {
   return new DefaultTranslation(options)
 }
 
 export class DefaultTranslation implements TranslationAdapter {
   #resources: Map<string, Record<string, string>> = new Map()
+  options: TranslationAdapterFactoryOptions
 
-  constructor(_options: TranslationAdapterFactoryOptions = {}) {
+  constructor(options: TranslationAdapterFactoryOptions) {
+    this.options = options
     this.#resources = new Map()
   }
 
@@ -32,15 +34,16 @@ export class DefaultTranslation implements TranslationAdapter {
   }
 
   translate(
-    message: string,
+    locale: string,
+    key: string,
     _values: Record<string, unknown> = create<Record<string, unknown>>()
-  ): string {
+  ): string | undefined {
     /**
      * NOTE:
      * DefaultTranslation support static message only
      * If you want to resolve message with values and use the complex message format,
      * you should inherit this class or implement your own translation adapter.
      */
-    return message
+    return this.getMessage(locale, key) || this.getMessage(this.options.fallbackLocale, key)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,14 +320,17 @@ export type CommandResourceFetcher<Options extends ArgOptions = ArgOptions> = (
  * Translation adapter factory
  */
 export type TranslationAdapterFactory = (
-  options?: TranslationAdapterFactoryOptions
+  options: TranslationAdapterFactoryOptions
 ) => TranslationAdapter
 
 /**
  * Translation adapter factory options
  */
 export interface TranslationAdapterFactoryOptions {
-  // TODO: add options, if we need thems
+  /**
+   * A fallback locale
+   */
+  fallbackLocale: string
 }
 
 /**
@@ -340,30 +343,31 @@ export interface TranslationAdapterFactoryOptions {
 export interface TranslationAdapter<MessageResource = string> {
   /**
    * Get a resource of locale
-   * @param locale A locale, that format is Unicord locale ID (BCP 47)
-   * @returns A resource of locale, if not found return `undefined`
+   * @param locale A Locale at the time of command execution. That is Unicord locale ID (BCP 47)
+   * @returns A resource of locale. if resource not found, return `undefined`
    */
   getResource(locale: string): Record<string, string> | undefined
   /**
    * Set a resource of locale
-   * @param locale A locale, that format is Unicord locale ID (BCP 47)
+   * @param locale A Locale at the time of command execution. That is Unicord locale ID (BCP 47)
    * @param resource A resource of locale
    */
   setResource(locale: string, resource: Record<string, string>): void
   /**
    * Get a message of locale
-   * @param locale A locale, that format is Unicord locale ID (BCP 47)
+   * @param locale A Locale at the time of command execution. That is Unicord locale ID (BCP 47)
    * @param key A key of message resource
-   * @returns A message of locale, if not found return `undefined`
+   * @returns A message of locale. if message not found, return `undefined`
    */
   getMessage(locale: string, key: string): MessageResource | undefined
   /**
    * Translate a message
-   * @param message A message of resource
+   * @param locale A Locale at the time of command execution. That is Unicord locale ID (BCP 47)
+   * @param key A key of message resource
    * @param values A values to be resolved in the message
-   * @returns A translated message
+   * @returns A translated message, if message is not translated, return `undefined`
    */
-  translate(message: string, values?: Record<string, unknown>): string
+  translate(locale: string, key: string, values?: Record<string, unknown>): string | undefined
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,11 @@ export interface CommandOptions<Options extends ArgOptions = ArgOptions> {
   renderValidationErrors?:
     | ((ctx: Readonly<CommandContext<Options>>, error: AggregateError) => Promise<string>)
     | null
+  /**
+   * Translation adapter factory
+   * @experimental
+   */
+  translationAdapterFactory?: TranslationAdapterFactory
 }
 
 /**
@@ -218,11 +223,13 @@ export interface CommandContext<
   /**
    * Translate function
    * @param key the key to be translated
+   * @param values the values to be formatted
    * @returns A translated string
    * @experimental
    */
   translate: <T extends string = CommandBuiltinKeys, Key = CommandBuiltinKeys | keyof Options | T>(
-    key: Key
+    key: Key,
+    values?: Record<string, unknown>
   ) => string
 }
 
@@ -308,6 +315,57 @@ export type CommandResource<Options extends ArgOptions = ArgOptions> = {
 export type CommandResourceFetcher<Options extends ArgOptions = ArgOptions> = (
   ctx: Readonly<CommandContext<Options>>
 ) => Promise<CommandResource<Options>>
+
+/**
+ * Translation adapter factory
+ */
+export type TranslationAdapterFactory = (
+  options?: TranslationAdapterFactoryOptions
+) => TranslationAdapter
+
+/**
+ * Translation adapter factory options
+ */
+export interface TranslationAdapterFactoryOptions {
+   
+  // TODO:
+}
+
+/**
+ * Translation adapter
+ *
+ * @description
+ * This adapter is used to custom message formatter like {@link https://github.com/intlify/vue-i18n/blob/master/spec/syntax.ebnf | Intlify message format}, {@link https://github.com/tc39/proposal-intl-messageformat | `Intl.MessageFormat` (MF2)}, and etc.
+ * This adapter will support localization with your preferred message format
+ */
+export interface TranslationAdapter<MessageResource = string> {
+  /**
+   * Get a resource of locale
+   * @param locale A locale, that format is Unicord locale ID (BCP 47)
+   * @returns A resource of locale, if not found return `undefined`
+   */
+  getResource(locale: string): Record<string, string> | undefined
+  /**
+   * Set a resource of locale
+   * @param locale A locale, that format is Unicord locale ID (BCP 47)
+   * @param resource A resource of locale
+   */
+  setResource(locale: string, resource: Record<string, string>): void
+  /**
+   * Get a message of locale
+   * @param locale A locale, that format is Unicord locale ID (BCP 47)
+   * @param key A key of message resource
+   * @returns A message of locale, if not found return `undefined`
+   */
+  getMessage(locale: string, key: string): MessageResource | undefined
+  /**
+   * Translate a message
+   * @param message A message of resource
+   * @param values A values to be resolved in the message
+   * @returns A translated message
+   */
+  translate(message: string, values?: Record<string, unknown>): string
+}
 
 /**
  * Command runner

--- a/src/types.ts
+++ b/src/types.ts
@@ -328,6 +328,10 @@ export type TranslationAdapterFactory = (
  */
 export interface TranslationAdapterFactoryOptions {
   /**
+   * A locale
+   */
+  locale: string
+  /**
    * A fallback locale
    */
   fallbackLocale: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,8 +327,7 @@ export type TranslationAdapterFactory = (
  * Translation adapter factory options
  */
 export interface TranslationAdapterFactoryOptions {
-   
-  // TODO:
+  // TODO: add options, if we need thems
 }
 
 /**

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,9 +1,15 @@
-import { createCoreContext, NOT_REOSLVED, translate } from '@intlify/core'
+import {
+  createCoreContext,
+  getLocaleMessage,
+  NOT_REOSLVED,
+  setLocaleMessage,
+  translate
+} from '@intlify/core'
 import { MessageFormat } from 'messageformat'
 import { vi } from 'vitest'
 import { DefaultTranslation } from '../src/translation.js'
 
-import type { CoreContext, LocaleMessage } from '@intlify/core'
+import type { CoreContext, LocaleMessage, LocaleMessageValue } from '@intlify/core'
 import type { TranslationAdapter, TranslationAdapterFactoryOptions } from '../src/types'
 
 export function defineMockLog(utils: typeof import('../src/utils')) {
@@ -98,11 +104,11 @@ class IntlifyMessageFormatTranslation implements TranslationAdapter {
   }
 
   getResource(locale: string): Record<string, string> | undefined {
-    return this.#context.messages[locale] as Record<string, string> | undefined
+    return getLocaleMessage(this.#context, locale)
   }
 
   setResource(locale: string, resource: Record<string, string>): void {
-    this.#context.messages[locale] = resource
+    setLocaleMessage(this.#context, locale, resource as LocaleMessageValue)
   }
 
   getMessage(locale: string, key: string): string | undefined {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,8 @@
+import { MessageFormat } from 'messageformat'
 import { vi } from 'vitest'
+import { DefaultTranslation } from '../src/translation.js'
+
+import type { TranslationAdapter, TranslationAdapterFactoryOptions } from '../src/types'
 
 export function defineMockLog(utils: typeof import('../src/utils')) {
   const logs: unknown[] = []
@@ -11,4 +15,54 @@ export function defineMockLog(utils: typeof import('../src/utils')) {
 
 export function hasPrototype(obj: unknown): boolean {
   return Object.getPrototypeOf(obj) !== null
+}
+
+export function createTranslationAdapterForMessageFormat2(
+  options: TranslationAdapterFactoryOptions
+): TranslationAdapter {
+  return new MessageFormat2Translation(options)
+}
+
+class MessageFormat2Translation extends DefaultTranslation {
+  #messageFormatCaches: Map<
+    string,
+    (values: Record<string, unknown>, onError: (err: Error) => void) => string | undefined
+  >
+
+  constructor(options: TranslationAdapterFactoryOptions) {
+    super(options)
+    this.#messageFormatCaches = new Map()
+  }
+
+  // override
+  translate(locale: string, key: string, values: Record<string, unknown>): string | undefined {
+    const message = super.translate(locale, key, values)
+    if (message == null) {
+      return message
+    }
+
+    const cacheKey = `${locale}:${key}:${message}`
+    let detectError = false
+    const onError = (err: Error) => {
+      console.error('[gunshi] message format2 error', err.message)
+      detectError = true
+    }
+
+    if (this.#messageFormatCaches.has(cacheKey)) {
+      const format = this.#messageFormatCaches.get(cacheKey)!
+      const formatted = format(values, onError)
+      return detectError ? undefined : formatted
+    }
+
+    const messageFormat = new MessageFormat(locale, message)
+    const format = (values: Record<string, unknown>, onError: (err: Error) => void) => {
+      return messageFormat.format(values, err => {
+        onError(err as Error)
+      })
+    }
+    this.#messageFormatCaches.set(cacheKey, format)
+    const formatted = format(values, onError)
+    console.log('MF2 formatted', formatted)
+    return detectError ? undefined : formatted
+  }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,9 @@
+import { createCoreContext, NOT_REOSLVED, translate } from '@intlify/core'
 import { MessageFormat } from 'messageformat'
 import { vi } from 'vitest'
 import { DefaultTranslation } from '../src/translation.js'
 
+import type { CoreContext, LocaleMessages, NamedValue } from '@intlify/core'
 import type { TranslationAdapter, TranslationAdapterFactoryOptions } from '../src/types'
 
 export function defineMockLog(utils: typeof import('../src/utils')) {
@@ -61,8 +63,67 @@ class MessageFormat2Translation extends DefaultTranslation {
       })
     }
     this.#messageFormatCaches.set(cacheKey, format)
+
     const formatted = format(values, onError)
-    console.log('MF2 formatted', formatted)
     return detectError ? undefined : formatted
+  }
+}
+
+export function createTranslationAdapterForIntlifyMessageFormat(
+  options: TranslationAdapterFactoryOptions
+): TranslationAdapter {
+  return new IntlifyMessageFormatTranslation(options)
+}
+
+class IntlifyMessageFormatTranslation implements TranslationAdapter {
+  options: TranslationAdapterFactoryOptions
+  #context: CoreContext
+  constructor(options: TranslationAdapterFactoryOptions) {
+    this.options = options
+
+    const { locale, fallbackLocale } = options
+    const messages: LocaleMessages<{}> = {
+      [locale]: {}
+    }
+
+    if (locale !== fallbackLocale) {
+      messages[fallbackLocale] = {}
+    }
+
+    this.#context = createCoreContext({
+      locale,
+      fallbackLocale,
+
+      messages
+    })
+  }
+
+  getResource(locale: string): Record<string, string> | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    return (this.#context.messages as any)[locale] as Record<string, string> | undefined
+  }
+
+  setResource(locale: string, resource: Record<string, string>): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    ;(this.#context.messages as any)[locale] = resource
+  }
+
+  getMessage(locale: string, key: string): string | undefined {
+    const resource = this.getResource(locale)
+    if (resource) {
+      return resource[key]
+    }
+    return undefined
+  }
+
+  translate(locale: string, key: string, values: Record<string, unknown>): string | undefined {
+    const message =
+      this.getMessage(locale, key) || this.getMessage(this.options.fallbackLocale, key)
+    if (message == null) {
+      return undefined
+    }
+
+    const ret = translate(this.#context, key, values as unknown as NamedValue)
+    return typeof ret === 'number' && ret === NOT_REOSLVED ? undefined : (ret as string)
   }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR introduces a mechanism to support various message formats such as intlify message format and `Intl.MessageFormat` (MF2).

This makes it possible to reduce the package size and make maintenance easier, as gunshi does not need to add its own message formatter or message format library as a dependency.
Complex message formatters are left to the users of gunshi.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
