### PR TITLE
breaking: drop `CommandRunner` on generate

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,18 +2,18 @@ import { cli } from './cli.ts'
 import { create } from './utils.ts'
 
 import { ArgOptions } from 'args-tokens'
-import type { Command, CommandOptions, CommandRunner } from './types.ts'
+import type { Command, CommandOptions } from './types.ts'
 
 /**
  * Generate the command usage
  * @param command - usage generate command, if you want to generate the usage of the default command where there are target commands and sub-commands, specify `null`.
- * @param entry - A {@link Command | entry command} or an {@link CommandRunner | inline command runner}
+ * @param entry - A {@link Command | entry command}
  * @param opts - A {@link CommandOptions | command options}
  * @returns A rendered usage
  */
 export async function generate<Options extends ArgOptions = ArgOptions>(
   command: string | null,
-  entry: Command<Options> | CommandRunner<Options>,
+  entry: Command<Options>,
   opts: CommandOptions<Options> = {}
 ): Promise<string> {
   const args = ['-h']


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This is because `CommandRunner`, i.e., the inline function, does not know the command name.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
