### PR TITLE
breaking: drop command `default` field

### DIFF
--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -90,7 +90,6 @@ await cli(process.argv.slice(2), command, {
 
 - `name`: The name of the command
 - `description`: A description of what the command does
-- `default`: (Optional) Set to `true` to make this the default command when no sub-command is specified
 
 ### Command Options
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -152,7 +152,7 @@ async function resolveCommand<Options extends ArgOptions>(
 ): Promise<[string | undefined, Command<Options> | undefined]> {
   const omitted = !sub
   if (typeof entry === 'function') {
-    return [undefined, { run: entry, default: true }]
+    return [undefined, { run: entry }]
   } else {
     if (omitted) {
       return typeof entry === 'object'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -156,7 +156,7 @@ async function resolveCommand<Options extends ArgOptions>(
   } else {
     if (omitted) {
       return typeof entry === 'object'
-        ? [entry.name, await resolveLazyCommand(entry, undefined, true)]
+        ? [entry.name, await resolveLazyCommand(entry)]
         : [undefined, undefined]
     } else {
       if (options.subCommands == null) {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -52,7 +52,6 @@ COMMANDS.set('command1', {
       description: 'The foo option'
     }
   },
-  default: true,
   description: 'this is command1',
   run: NOOP
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,11 +261,6 @@ export interface Command<Options extends ArgOptions = ArgOptions> {
    */
   description?: string
   /**
-   * whether the command is default or not
-   * @description if the command is default, it is executed when no sub-command is specified
-   */
-  default?: boolean
-  /**
    * Command options
    * @description each option can include a description property to describe the option in usage.
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import type {
 
 export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions>(
   cmd: Commandable<Options>,
-  name: string | undefined
+  name?: string | undefined
 ): Promise<Command<Options>> {
   const resolved = Object.assign(
     create<Command<Options>>(),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,13 +11,11 @@ import type {
 
 export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions>(
   cmd: Commandable<Options>,
-  name: string | undefined,
-  entry: boolean = false
+  name: string | undefined
 ): Promise<Command<Options>> {
   const resolved = Object.assign(
     create<Command<Options>>(),
-    typeof cmd == 'function' ? await cmd() : cmd,
-    { default: entry }
+    typeof cmd == 'function' ? await cmd() : cmd
   )
 
   if (resolved.name == null && name) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Because we are not using it at this time. Initially, I thought this `default` would be needed to resolve the `args` argument of the `cli` function with the sub command passed to the `options` of that function when the command is omitted. As it turns out, I don't have to use it, but I can solve the problem at this point.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
