### PR TITLE
breaking: `'description'` resolving

### DIFF
--- a/docs/guide/essentials/internationalization.md
+++ b/docs/guide/essentials/internationalization.md
@@ -241,9 +241,71 @@ await cli(process.argv.slice(2), command, {
 
 For earlier Node.js versions, you can use environment variables or configuration files to determine the locale.
 
-## Resource structure and reserved resource keys
+## Resource Key Naming Conventions
 
-TODO:
+When defining your localization resources (either directly in the `resource` function or in separate files), there are specific naming conventions to follow for the keys:
+
+- **Command Description**: Use the key `description` for the main description of the command.
+- **Examples**: Use the key `examples` for usage examples.
+- **Option Descriptions**: Keys for the descriptions of command options **must** be prefixed with `Option:`. For example, if you have an option named `target`, its description key must be `Option:target`. This prefix is crucial to avoid naming conflicts with other keys like `description` or custom keys.
+- **Custom Keys**: Any other keys you define for custom translation messages (like greetings, error messages, etc.) do not require a prefix and can be named freely (e.g., `informal_greeting`, `error_file_not_found`).
+- **Built-in Keys**: Keys for built-in functionalities like `help` and `version` are generally handled by Gunshi's default locales. While you can technically override them using keys like `_help` and `_version`, it's usually sufficient to rely on the default translations provided.
+
+Here's an example illustrating the convention:
+
+```ts
+import { define } from 'gunshi'
+
+const command = define({
+  name: 'my-command',
+  options: {
+    target: { type: 'string' },
+    verbose: { type: 'boolean' }
+  },
+  resource: async ctx => {
+    // Example for 'en-US' locale
+    return {
+      description: 'This is my command.', // No prefix
+      examples: '$ my-command --target file.txt', // No prefix
+      'Option:target': 'The target file to process.', // 'Option:' prefix
+      'Option:verbose': 'Enable verbose output.', // 'Option:' prefix
+      processing_message: 'Processing target...' // No prefix
+    }
+  },
+  run: ctx => {
+    /* ... */
+  }
+})
+```
+
+Adhering to these conventions ensures that Gunshi correctly identifies and uses your translations for descriptions, help messages, and within your command's logic via `ctx.translate()`.
+
+<!-- eslint-disable markdown/no-missing-label-refs -->
+
+> [!IMPORTANT]
+> The resource object returned by the `resource` function (or loaded from external files like JSON) **must** be a flat key-value structure. Nested objects are not supported for translations using `ctx.translate()`. Keep your translation keys simple and at the top level.
+
+<!-- eslint-enable markdown/no-missing-label-refs -->
+
+Good Flat structure:
+
+```json
+{
+  "greeting": "Hello",
+  "farewell": "Goodbye"
+}
+```
+
+Bad Nested structure (won't work with `ctx.translate('messages.greeting')`:
+
+```json
+{
+  "messages": {
+    "greeting": "Hello",
+    "farewell": "Goodbye"
+  }
+}
+```
 
 ## Internationalization with Sub-commands
 

--- a/docs/guide/essentials/internationalization.md
+++ b/docs/guide/essentials/internationalization.md
@@ -37,8 +37,8 @@ const command = {
     if (ctx.locale.toString() === 'ja-JP') {
       return {
         description: '挨拶アプリケーション',
-        name: '挨拶する相手の名前',
-        formal: '丁寧な挨拶を使用する',
+        'Option:name': '挨拶する相手の名前',
+        'Option:formal': '丁寧な挨拶を使用する',
         informal_greeting: 'こんにちは',
         formal_greeting: 'はじめまして'
       }
@@ -47,8 +47,8 @@ const command = {
     // Default to English
     return {
       description: 'Greeting application',
-      name: 'Name to greet',
-      formal: 'Use formal greeting',
+      'Option:name': 'Name to greet',
+      'Option:formal': 'Use formal greeting',
       informal_greeting: 'Hello',
       formal_greeting: 'Good day'
     }
@@ -153,8 +153,8 @@ Example locale files:
 ```json
 {
   "description": "Greeting application",
-  "name": "Name to greet",
-  "formal": "Use formal greeting",
+  "Option:name": "Name to greet",
+  "Option:formal": "Use formal greeting",
   "informal_greeting": "Hello",
   "formal_greeting": "Good day"
 }
@@ -165,8 +165,8 @@ Example locale files:
 ```json
 {
   "description": "挨拶アプリケーション",
-  "name": "挨拶する相手の名前",
-  "formal": "丁寧な挨拶を使用する",
+  "Option:name": "挨拶する相手の名前",
+  "Option:formal": "丁寧な挨拶を使用する",
   "informal_greeting": "こんにちは",
   "formal_greeting": "はじめまして"
 }
@@ -361,8 +361,8 @@ const command = {
     // Show translation information
     console.log('\nTranslation Information:')
     console.log(`Command Description: ${ctx.translate('description')}`)
-    console.log(`Name Option: ${ctx.translate('name')}`)
-    console.log(`Formal Option: ${ctx.translate('formal')}`)
+    console.log(`Name Option: ${ctx.translate('Option:name')}`)
+    console.log(`Formal Option: ${ctx.translate('Option:formal')}`)
   }
 }
 
@@ -383,8 +383,8 @@ With locale files:
 ```json
 {
   "description": "Greeting application",
-  "name": "Name to greet",
-  "formal": "Use formal greeting",
+  "Option:name": "Name to greet",
+  "Option:formal": "Use formal greeting",
   "informal_greeting": "Hello",
   "formal_greeting": "Good day"
 }
@@ -395,8 +395,8 @@ With locale files:
 ```json
 {
   "description": "挨拶アプリケーション",
-  "name": "挨拶する相手の名前",
-  "formal": "丁寧な挨拶を使用する",
+  "Option:name": "挨拶する相手の名前",
+  "Option:formal": "丁寧な挨拶を使用する",
   "informal_greeting": "こんにちは",
   "formal_greeting": "はじめまして"
 }

--- a/playground/deno/locales/en-US.json
+++ b/playground/deno/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "description": "create a new resource",
   "examples": "# Create a resource example1\n$ deno run index.ts create --name my-resource --type special",
-  "name": "Name of the resource to create",
-  "type": "Type of resource to create (default: \"default\")"
+  "Option:name": "Name of the resource to create",
+  "Option:type": "Type of resource to create (default: \"default\")"
 }

--- a/playground/deno/locales/ja-JP.json
+++ b/playground/deno/locales/ja-JP.json
@@ -1,6 +1,6 @@
 {
   "description": "リソースの新規作成",
   "examples": "# リソースの作成例1\n$ deno run index.ts create --name my-resource --type special",
-  "name": "作成するリソースの名前",
-  "type": "作成するリソースのタイプ (デフォルト: \"default\")"
+  "Option:name": "作成するリソースの名前",
+  "Option:type": "作成するリソースのタイプ (デフォルト: \"default\")"
 }

--- a/playground/i18n/locales/en-US.json
+++ b/playground/i18n/locales/en-US.json
@@ -1,8 +1,8 @@
 {
   "description": "A greeting application with internationalization support",
   "examples": "# Basic greeting\n$ node index.js --name John\n\n# Formal greeting in Japanese\n$ MY_LOCALE=ja-JP node index.js --name 田中 --formal",
-  "name": "Name to greet",
-  "formal": "Use formal greeting",
+  "Option:name": "Name to greet",
+  "Option:formal": "Use formal greeting",
   "formal_greeting": "Good day",
   "informal_greeting": "Hello"
 }

--- a/playground/i18n/locales/ja-JP.json
+++ b/playground/i18n/locales/ja-JP.json
@@ -1,8 +1,8 @@
 {
   "description": "国際化対応の挨拶アプリケーション",
-  "examples": "# 基本的な挨拶\n$ node index.js --name 田中\n\n# 日本語での丁寧な挨拶\n$ MY_LOCALE=ja-JP node index.js --name 田中 --formal",
-  "name": "挨拶する相手の名前",
-  "formal": "丁寧な挨拶を使用する",
-  "formal_greeting": "はじめまして",
-  "informal_greeting": "こんにちは"
+  "examples": "# 基本的な挨拶\n$ node index.js --name John\n\n# 日本語での丁寧な挨拶\n$ MY_LOCALE=ja-JP node index.js --name 田中 --formal",
+  "Option:name": "挨拶する名前",
+  "Option:formal": "丁寧な挨拶を使用する",
+  "formal_greeting": "こんにちは",
+  "informal_greeting": "やあ"
 }

--- a/src/__snapshots__/cli.test.ts.snap
+++ b/src/__snapshots__/cli.test.ts.snap
@@ -253,6 +253,19 @@ Options:
 ******************************"
 `;
 
+exports[`edge cases > 'description' option 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+
+USAGE:
+  gunshi <OPTIONS> 
+
+OPTIONS:
+  -d, --description <description>          This is a description of description option
+  -h, --help                               Display this help message
+  -v, --version                            Display this version
+"
+`;
+
 exports[`usageSilent 1`] = `
 "Modern CLI tool (gunshi v0.0.0)
 USAGE:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { defineMockLog } from '../test/utils.ts'
 import { cli } from './cli.ts'
+import { define } from './definition.ts'
 import { renderValidationErrors } from './renderer/index.ts'
 
 import type { ArgOptions } from 'args-tokens'
@@ -460,4 +461,33 @@ test('tokens', async () => {
       value: 'bar'
     }
   ])
+})
+
+describe('edge cases', () => {
+  test(`'description' option`, async () => {
+    const command = define({
+      name: 'test',
+      description: 'This is a test command',
+      options: {
+        description: {
+          type: 'string',
+          short: 'd',
+          description: 'This is a description of description option'
+        }
+      },
+      run: vi.fn()
+    })
+
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await cli(['-h'], command, {
+      name: 'gunshi',
+      description: 'Modern CLI tool',
+      version: '0.0.0'
+    })
+
+    const stdout = log()
+    expect(stdout).toMatchSnapshot()
+  })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,8 @@ export const DEFAULT_LOCALE = 'en-US'
 
 export const BUILT_IN_PREFIX = '_'
 
+export const OPTION_PREFIX = 'Option'
+
 export const BUILT_IN_KEY_SEPARATOR = ':'
 
 export const NOOP: () => void = () => {}

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -9,7 +9,7 @@ import { DEFAULT_LOCALE } from './constants.ts'
 import { createCommandContext } from './context.ts'
 import DefaultLocale from './locales/en-US.json' with { type: 'json' }
 import jaLocale from './locales/ja-JP.json' with { type: 'json' }
-import { resolveBuiltInKey } from './utils.ts'
+import { resolveBuiltInKey, resolveOptionKey } from './utils.ts'
 
 import type { ArgOptions } from 'args-tokens'
 import type { Command, CommandResource, CommandResourceFetcher, LazyCommand } from './types.ts'
@@ -95,9 +95,9 @@ test('basic', async () => {
     renderValidationErrors: mockRenderValidationErrors
   })
 
-  expect(ctx.translate('foo')).toEqual('this is foo option')
-  expect(ctx.translate('bar')).toEqual('this is bar option')
-  expect(ctx.translate('baz')).toEqual('this is baz option')
+  expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual('this is foo option')
+  expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual('this is bar option')
+  expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual('this is baz option')
   expect(ctx.translate(resolveBuiltInKey('help'))).toEqual('Display this help message')
   expect(ctx.translate(resolveBuiltInKey('version'))).toEqual('Display this version')
   expect(ctx.translate('examples')).toEqual('examples')
@@ -252,10 +252,10 @@ describe('translation', () => {
     // description, options, and examples
     expect(ctx.translate(resolveBuiltInKey('help'))).toEqual(DefaultLocale.help)
     expect(ctx.translate(resolveBuiltInKey('version'))).toEqual(DefaultLocale.version)
+    expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual('this is foo option')
+    expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual('this is bar option')
+    expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual('this is baz option')
     expect(ctx.translate('description')).toEqual('this is cmd1')
-    expect(ctx.translate('foo')).toEqual('this is foo option')
-    expect(ctx.translate('bar')).toEqual('this is bar option')
-    expect(ctx.translate('baz')).toEqual('this is baz option')
     expect(ctx.translate('examples')).toEqual('this is an cmd1 example')
   })
 
@@ -280,9 +280,9 @@ describe('translation', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      foo: 'これは foo オプションです',
-      bar: 'これは bar オプションです',
-      baz: 'これは baz オプションです',
+      'Option:foo': 'これは foo オプションです',
+      'Option:bar': 'これは bar オプションです',
+      'Option:baz': 'これは baz オプションです',
       examples: 'これはコマンド1の例です',
       test: 'これはテストです'
     } satisfies CommandResource<typeof options>
@@ -328,9 +328,15 @@ describe('translation', () => {
 
     // description, options, and examples
     expect(ctx.translate('description')).toEqual(jaJPResource.description)
-    expect(ctx.translate('foo')).toEqual(jaJPResource.foo)
-    expect(ctx.translate('bar')).toEqual(jaJPResource.bar)
-    expect(ctx.translate('baz')).toEqual(jaJPResource.baz)
+    expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual(
+      jaJPResource['Option:foo']
+    )
+    expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual(
+      jaJPResource['Option:bar']
+    )
+    expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual(
+      jaJPResource['Option:baz']
+    )
     expect(ctx.translate('examples')).toEqual(jaJPResource.examples)
 
     // user defined resource
@@ -350,7 +356,7 @@ describe('translation adapter', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      foo: 'これは foo オプションです',
+      'Option:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{$user}'
     } satisfies CommandResource<typeof options>
@@ -388,8 +394,10 @@ describe('translation adapter', () => {
       }
     })
 
-    const mf = new MessageFormat('ja-JP', jaJPResource.user)
-    expect(ctx.translate('user', { user: 'kazupon' })).toEqual(mf.format({ user: 'kazupon' }))
+    const mf1 = new MessageFormat('ja-JP', jaJPResource['Option:foo'])
+    expect(ctx.translate('Option:foo')).toEqual(mf1.format())
+    const mf2 = new MessageFormat('ja-JP', jaJPResource.user)
+    expect(ctx.translate('user', { user: 'kazupon' })).toEqual(mf2.format({ user: 'kazupon' }))
   })
 
   test('Intlify Message Format', async () => {
@@ -403,7 +411,7 @@ describe('translation adapter', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      foo: 'これは foo オプションです',
+      'Option:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{user}'
     } satisfies CommandResource<typeof options>
@@ -441,6 +449,7 @@ describe('translation adapter', () => {
       }
     })
 
+    expect(ctx.translate('Option:foo')).toEqual(jaJPResource['Option:foo'])
     expect(ctx.translate('user', { user: 'kazupon' })).toEqual(`こんにちは、kazupon`)
   })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,14 @@
 import { BUILT_IN_PREFIX, COMMAND_OPTIONS_DEFAULT, DEFAULT_LOCALE, NOOP } from './constants.ts'
 import DefaultResource from './locales/en-US.json' with { type: 'json' }
 import { createTranslationAdapter } from './translation.ts'
-import { create, deepFreeze, log, mapResourceWithBuiltinKey, resolveLazyCommand } from './utils.ts'
+import {
+  create,
+  deepFreeze,
+  log,
+  mapResourceWithBuiltinKey,
+  resolveLazyCommand,
+  resolveOptionKey
+} from './utils.ts'
 
 import type { ArgOptions, ArgOptionSchema, ArgToken, ArgValues } from 'args-tokens'
 import type {
@@ -196,7 +203,7 @@ export async function createCommandContext<
   })
 
   const defaultCommandResource = loadedOptionsResources.reduce((res, [key, value]) => {
-    res[key] = value
+    res[resolveOptionKey(key)] = value
     return res
   }, create<Record<string, string>>())
   defaultCommandResource.description = command.description || ''

--- a/src/renderer/usage.ts
+++ b/src/renderer/usage.ts
@@ -1,4 +1,4 @@
-import { create, resolveBuiltInKey } from '../utils.ts'
+import { create, resolveBuiltInKey, resolveOptionKey } from '../utils.ts'
 
 import type { ArgOptions } from 'args-tokens'
 import type { Command, CommandContext } from '../types.ts'
@@ -257,7 +257,7 @@ async function generateOptionsUsage<Options extends ArgOptions>(
 
   const usages = await Promise.all(
     Object.entries(optionsPairs).map(([key, value]) => {
-      const rawDesc = ctx.translate(key)
+      const rawDesc = ctx.translate(resolveOptionKey(key))
       const optionsSchema = ctx.env.usageOptionType ? `[${ctx.options[key].type}] ` : ''
       // padEnd is used to align the `[]` symbols
       const desc = `${optionsSchema ? optionsSchema.padEnd(optionSchemaMaxLength + 3) : ''}${rawDesc}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { BUILT_IN_KEY_SEPARATOR, BUILT_IN_PREFIX } from './constants.ts'
+import { BUILT_IN_KEY_SEPARATOR, BUILT_IN_PREFIX, OPTION_PREFIX } from './constants.ts'
 
 import type { ArgOptions } from 'args-tokens'
 import type {
@@ -6,7 +6,8 @@ import type {
   Commandable,
   CommandBuiltinOptionsKeys,
   CommandBuiltinResourceKeys,
-  GenerateNamespacedKey
+  GenerateNamespacedKey,
+  RemovedIndex
 } from './types.ts'
 
 export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions>(
@@ -28,6 +29,13 @@ export function resolveBuiltInKey<
   Key extends string = CommandBuiltinOptionsKeys | CommandBuiltinResourceKeys
 >(key: Key): GenerateNamespacedKey<Key> {
   return `${BUILT_IN_PREFIX}${BUILT_IN_KEY_SEPARATOR}${key}`
+}
+
+export function resolveOptionKey<
+  Options extends ArgOptions = {},
+  Key extends string = keyof RemovedIndex<Options>
+>(key: Key): GenerateNamespacedKey<Key, typeof OPTION_PREFIX> {
+  return `${OPTION_PREFIX}${BUILT_IN_KEY_SEPARATOR}${key}`
 }
 
 export function mapResourceWithBuiltinKey(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -108,6 +108,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "src/definitionts"],
   "exclude": ["playground/bun/index.ts", "playground/deno/main.ts"]
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

resolve #63 

This PR fixes an issue where the `description` option was not correctly reflected in the defined usage.

This problem was caused by `Command.options` and `Command.resource` conflicting with `Command` s `description`.
The description of options is closely related to the i18n function and implementation of gunshi. As a solution to the conflict, if you define the description of options in the resource obtained by `Command.resource`, you can resolve the conflict by defining the resource key with the prefix `'Option:'`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
