### PR TITLE
feat: support rest arguments

### DIFF
--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -79,6 +79,8 @@ $ node index.js --name World
 $ node index.js -n World -g "Hey there" -t 3
 # Boolean short options can be grouped: -V -b is the same as -Vb
 $ node index.js -Vb -n World
+# Using rest arguments after \`--\` (arguments after \`--\` are not parsed by gunshi)
+$ node index.js -n User -- --foo --bar buz
 `,
 
   // Command execution function
@@ -92,11 +94,20 @@ $ node index.js -Vb -n World
     if (verbose) {
       console.log('Running in verbose mode...')
       console.log('Context values:', ctx.values)
+      console.log('Positional arguments:', ctx.positionals) // Show positionals
     }
 
     // Repeat the greeting the specified number of times
     for (let i = 0; i < times; i++) {
       console.log(`${greeting}, ${name}!`)
+    }
+
+    // Print rest arguments if they exist
+    if (ctx.rest.length > 0) {
+      console.log('\nRest arguments received:')
+      for (const [index, arg] of ctx.rest.entries()) {
+        console.log(`  ${index + 1}: ${arg}`)
+      }
     }
   }
 }
@@ -141,6 +152,7 @@ The `run` function receives a command context object (`ctx`) with:
 - `options`: The command options configuration
 - `values`: The resolved option values
 - `positionals`: Positional arguments
+- `rest`: Rest arguments (arguments appearing after `--`)
 - `_`: The raw arguments is passed from `cli` function
 - `name`: The command name
 - `description`: The command description

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -536,6 +536,22 @@ test('option grouping', async () => {
   expect(mockFn.mock.calls[0][0].values).toEqual({ silent: true, verbose: true })
 })
 
+test('rest arguments', async () => {
+  const args = ['--foo', 'bar', '--', '--baz', 'qux']
+  const mockFn = vi.fn()
+  await cli(args, {
+    options: {
+      foo: {
+        type: 'string',
+        short: 'f'
+      }
+    },
+    run: mockFn
+  })
+
+  expect(mockFn.mock.calls[0][0].rest).toEqual(['--baz', 'qux'])
+})
+
 describe('edge cases', () => {
   test(`'description' option`, async () => {
     const command = define({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ export async function cli<Options extends ArgOptions = ArgOptions>(
 
   const options = resolveArgOptions(command.options)
 
-  const { values, positionals, error } = resolveArgs(options, tokens, {
+  const { values, positionals, rest, error } = resolveArgs(options, tokens, {
     optionGrouping: true
   })
   const omitted = !subCommand
@@ -43,6 +43,7 @@ export async function cli<Options extends ArgOptions = ArgOptions>(
     options,
     values,
     positionals,
+    rest,
     args,
     tokens,
     omitted,

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -51,6 +51,7 @@ test('basic', async () => {
     options,
     values: { foo: 'foo', bar: true, baz: 42 },
     positionals: ['bar'],
+    rest: [],
     args: ['bar'],
     tokens: [], // dummy, due to test
     omitted: true,
@@ -138,6 +139,7 @@ test('default', async () => {
     options: {},
     values: { foo: 'foo', bar: true, baz: 42 },
     positionals: ['bar'],
+    rest: [],
     args: ['bar'],
     tokens: [], // dummy, due to test
     command,
@@ -183,6 +185,7 @@ describe('translation', () => {
       options: {},
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
+      rest: [],
       args: ['bar'],
       tokens: [], // dummy, due to test
       command,
@@ -242,6 +245,7 @@ describe('translation', () => {
       options,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
+      rest: [],
       args: ['bar'],
       tokens: [], // dummy, due to test
       command,
@@ -309,6 +313,7 @@ describe('translation', () => {
       options,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
+      rest: [],
       args: ['bar'],
       tokens: [], // dummy, due to test
       command,
@@ -383,6 +388,7 @@ describe('translation adapter', () => {
       options,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
+      rest: [],
       args: ['bar'],
       tokens: [], // dummy, due to test
       command,
@@ -438,6 +444,7 @@ describe('translation adapter', () => {
       options,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
+      rest: [],
       args: ['bar'],
       tokens: [], // dummy, due to test
       command,

--- a/src/context.ts
+++ b/src/context.ts
@@ -44,6 +44,10 @@ interface CommandContextParams<Options extends ArgOptions, Values> {
    */
   positionals: string[]
   /**
+   * A rest arguments, which passed to the target command
+   */
+  rest: string[]
+  /**
    * Original command line arguments
    */
   args: string[]
@@ -77,6 +81,7 @@ export async function createCommandContext<
   options,
   values,
   positionals,
+  rest,
   args,
   tokens,
   command,
@@ -187,6 +192,7 @@ export async function createCommandContext<
       options: _options,
       values,
       positionals,
+      rest,
       _: args,
       tokens,
       log: commandOptions.usageSilent ? NOOP : log,

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -82,6 +82,7 @@ describe('renderHeader', () => {
       options: {},
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: true,
@@ -102,6 +103,7 @@ describe('renderHeader', () => {
       options: {},
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: true,
@@ -121,6 +123,7 @@ describe('renderHeader', () => {
       options: {},
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: true,
@@ -136,6 +139,7 @@ describe('renderHeader', () => {
       options: {},
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: true,
@@ -186,6 +190,7 @@ describe('renderUsage', () => {
       options: command.options!,
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: false,
@@ -213,6 +218,7 @@ describe('renderUsage', () => {
       options: {},
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: false,
@@ -254,6 +260,7 @@ describe('renderUsage', () => {
       options: command.options!,
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: false,
@@ -301,6 +308,7 @@ describe('renderUsage', () => {
       options: command.options!,
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: false,
@@ -349,6 +357,7 @@ describe('renderUsage', () => {
       options: command.options!,
       values: {},
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       omitted: false,
@@ -372,6 +381,7 @@ describe('renderUsage', () => {
       values: {},
       omitted: true,
       positionals: [],
+      rest: [],
       args: [],
       tokens: [], // dummy, due to test
       command: SHOW,
@@ -392,6 +402,7 @@ test('renderValidationErrors', async () => {
     options: SHOW.options!,
     values: {},
     positionals: [],
+    rest: [],
     args: [],
     tokens: [], // dummy, due to test
     omitted: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,10 @@ export interface CommandContext<
    */
   positionals: string[]
   /**
+   * Command rest arguments, that is the remaining argument not resolved by the optional command option delimiter `--`.
+   */
+  rest: string[]
+  /**
    * Original command line arguments.
    * This argument is passed from `cli` function.
    */


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the option terminate `--` is specified, gunshi will support obtaining arguments that exist after it, as rest arguments.

This feature is useful when executing external scripts or commands such as `npm run`, allowing you to pass rest arguments as they are.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

related #78 
related #51 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
