### PR TITLE
breaking: change the interfaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "*.json": "jsonc"
   },
   "typescript.referencesCodeLens.enabled": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "deno.enable": false
 }

--- a/docs/guide/advanced/custom-usage-generation.md
+++ b/docs/guide/advanced/custom-usage-generation.md
@@ -56,7 +56,7 @@ const customHeaderRenderer = ctx => {
 const command = {
   name: 'app',
   description: 'My application',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -118,10 +118,10 @@ const customUsageRenderer = ctx => {
   lines.push('')
 
   // Add options section with custom formatting
-  if (ctx.options && Object.keys(ctx.options).length > 0) {
+  if (ctx.args && Object.keys(ctx.args).length > 0) {
     lines.push('OPTIONS:')
 
-    for (const [key, option] of Object.entries(ctx.options)) {
+    for (const [key, option] of Object.entries(ctx.args)) {
       const shortFlag = option.short ? `-${option.short}|` : '    '
       const required = option.required ? ' (required)' : ''
       const type = option.type ? ` <${option.type}>` : ''
@@ -240,7 +240,7 @@ const customValidationErrorsRenderer = (ctx, error) => {
 const command = {
   name: 'task-manager',
   description: 'A task management utility',
-  options: {
+  args: {
     action: {
       type: 'string',
       short: 'a',
@@ -291,7 +291,7 @@ import { cli } from 'gunshi'
 const command = {
   name: 'task-manager',
   description: 'A task management utility',
-  options: {
+  args: {
     add: {
       type: 'string',
       short: 'a',
@@ -390,10 +390,10 @@ const coloredUsageRenderer = ctx => {
   lines.push(chalk.white(`  $ ${ctx.env.name} [options]`))
   lines.push('')
 
-  if (ctx.options && Object.keys(ctx.options).length > 0) {
+  if (ctx.args && Object.keys(ctx.args).length > 0) {
     lines.push(chalk.white.bold('OPTIONS:'))
 
-    for (const [key, option] of Object.entries(ctx.options)) {
+    for (const [key, option] of Object.entries(ctx.args)) {
       const shortFlag = option.short ? chalk.green(`-${option.short}, `) : '    '
       const longFlag = chalk.green(`--${key}`)
       const type = chalk.blue(`[${option.type}]`)
@@ -427,7 +427,7 @@ The renderer functions receive a command context object (`ctx`) with the followi
 - `env`: Environment information (name, version, description)
 - `name`: Command name
 - `description`: Command description
-- `options`: Command options
+- `args`: Command arguments
 - `examples`: Command examples
 - `translate`: Translation function
 - `locale`: Current locale
@@ -475,10 +475,10 @@ const customUsageRenderer = ctx => {
   lines.push('')
 
   // Add options section with custom formatting
-  if (ctx.options && Object.keys(ctx.options).length > 0) {
+  if (ctx.args && Object.keys(ctx.args).length > 0) {
     lines.push('OPTIONS:')
 
-    for (const [key, option] of Object.entries(ctx.options)) {
+    for (const [key, option] of Object.entries(ctx.args)) {
       const shortFlag = option.short ? `-${option.short}, ` : '    '
       const longFlag = `--${key}`
       const type = `[${option.type}]`
@@ -533,7 +533,7 @@ const customValidationErrorsRenderer = (ctx, error) => {
 const command = {
   name: 'task-manager',
   description: 'A task management utility with custom usage generation',
-  options: {
+  args: {
     add: {
       type: 'string',
       short: 'a',

--- a/docs/guide/advanced/documentation-generation.md
+++ b/docs/guide/advanced/documentation-generation.md
@@ -14,7 +14,7 @@ import { promises as fs } from 'node:fs'
 const command = {
   name: 'my-command',
   description: 'A sample command',
-  options: {
+  args: {
     input: {
       type: 'string',
       short: 'i',
@@ -68,7 +68,7 @@ import { promises as fs } from 'node:fs'
 const createCommand = {
   name: 'create',
   description: 'Create a new resource',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -84,7 +84,7 @@ const createCommand = {
 const listCommand = {
   name: 'list',
   description: 'List all resources',
-  options: {
+  args: {
     format: {
       type: 'string',
       short: 'f',
@@ -153,7 +153,7 @@ async function main() {
   const command = {
     name: 'data-processor',
     description: 'Process data files',
-    options: {
+    args: {
       input: {
         type: 'string',
         short: 'i',
@@ -354,7 +354,7 @@ function renderManPageUsage(ctx) {
 
   // OPTIONS
   lines.push('## OPTIONS')
-  for (const [name, schema] of Object.entries(ctx.options)) {
+  for (const [name, schema] of Object.entries(ctx.args)) {
     const options = [`\`--${name}\``]
     if (schema.short) {
       options.unshift(`\`-${schema.short}\``)
@@ -389,7 +389,7 @@ async function main() {
   const command = {
     name: 'my-tool',
     description: 'A utility for processing data',
-    options: {
+    args: {
       input: {
         type: 'string',
         short: 'i',

--- a/docs/guide/advanced/translation-adapter.md
+++ b/docs/guide/advanced/translation-adapter.md
@@ -123,7 +123,7 @@ class MyTranslationAdapter {
 // Define your command
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'
@@ -260,7 +260,7 @@ class MessageFormatTranslation {
 // Define your command
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'
@@ -394,7 +394,7 @@ class IntlifyTranslation {
 // Define your command
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'

--- a/docs/guide/essentials/auto-usage-generation.md
+++ b/docs/guide/essentials/auto-usage-generation.md
@@ -13,8 +13,8 @@ const command = {
   name: 'file-manager',
   description: 'A file management utility',
 
-  // Define options with descriptions
-  options: {
+  // Define arguments with descriptions
+  args: {
     path: {
       type: 'string',
       short: 'p',
@@ -116,7 +116,7 @@ import { cli } from 'gunshi'
 const createCommand = {
   name: 'create',
   description: 'Create a new resource',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',

--- a/docs/guide/essentials/composable.md
+++ b/docs/guide/essentials/composable.md
@@ -36,7 +36,7 @@ import { cli } from 'gunshi'
 const createCommand = {
   name: 'create',
   description: 'Create a new resource',
-  options: {
+  args: {
     name: { type: 'string', short: 'n' }
   },
   run: ctx => {
@@ -80,12 +80,12 @@ When working with sub-commands, you can maintain type safety:
 
 ```ts
 import { cli } from 'gunshi'
-import type { ArgOptions, Command } from 'gunshi'
+import type { Args, Command } from 'gunshi'
 
 // Define type-safe sub-commands
-const createCommand: Command<ArgOptions> = {
+const createCommand: Command<Args> = {
   name: 'create',
-  options: {
+  args: {
     name: { type: 'string', short: 'n' }
   },
   run: ctx => {
@@ -93,7 +93,7 @@ const createCommand: Command<ArgOptions> = {
   }
 }
 
-const listCommand: Command<ArgOptions> = {
+const listCommand: Command<Args> = {
   name: 'list',
   run: () => {
     console.log('Listing items...')
@@ -101,12 +101,12 @@ const listCommand: Command<ArgOptions> = {
 }
 
 // Create a Map of sub-commands
-const subCommands = new Map<string, Command<ArgOptions>>()
+const subCommands = new Map<string, Command<Args>>()
 subCommands.set('create', createCommand)
 subCommands.set('list', listCommand)
 
 // Define the main command
-const mainCommand: Command<ArgOptions> = {
+const mainCommand: Command<Args> = {
   name: 'app',
   run: () => {
     console.log('Use a sub-command: create, list')

--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -40,8 +40,8 @@ const command = {
   name: 'greet',
   description: 'A greeting command with declarative configuration',
 
-  // Command options with descriptions
-  options: {
+  // Command arguments with descriptions
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -172,7 +172,7 @@ The `examples` property provides example commands showing how to use the CLI.
 
 The `run` function receives a command context object (`ctx`) with:
 
-- `options`: The command options configuration
+- `args`: The command arguments configuration
 - `values`: The resolved option values
 - `positionals`: Positional arguments
 - `rest`: Rest arguments (arguments appearing after `--`)

--- a/docs/guide/essentials/getting-started.md
+++ b/docs/guide/essentials/getting-started.md
@@ -67,7 +67,7 @@ import { cli } from 'gunshi'
 const command = {
   name: 'greeter',
   description: 'A simple greeting CLI',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',

--- a/docs/guide/essentials/internationalization.md
+++ b/docs/guide/essentials/internationalization.md
@@ -20,7 +20,7 @@ import { cli } from 'gunshi'
 // Define a command with i18n support
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'
@@ -115,7 +115,7 @@ import enUS from './locales/en-US.json' with { type: 'json' }
 
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: { type: 'string', short: 'n' },
     formal: { type: 'boolean', short: 'f' }
   },
@@ -179,7 +179,7 @@ Gunshi automatically uses your translations for help messages:
 ```js
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: { type: 'string', short: 'n' },
     formal: { type: 'boolean', short: 'f' }
   },
@@ -259,7 +259,7 @@ import { define } from 'gunshi'
 
 const command = define({
   name: 'my-command',
-  options: {
+  args: {
     target: { type: 'string' },
     verbose: { type: 'boolean' }
   },
@@ -321,7 +321,7 @@ import enUSForMain from './locales/main/en-US.json' with { type: 'json' }
 // Define sub-commands
 const createCommand = {
   name: 'create',
-  options: {
+  args: {
     name: { type: 'string', short: 'n' }
   },
 
@@ -382,7 +382,7 @@ import enUS from './locales/en-US.json' with { type: 'json' }
 
 const command = {
   name: 'greeter',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'

--- a/docs/guide/essentials/lazy-async.md
+++ b/docs/guide/essentials/lazy-async.md
@@ -35,7 +35,7 @@ import { cli, lazy } from 'gunshi'
 const helloDefinition = {
   name: 'hello', // This name is used as the key in subCommands Map
   description: 'A command whose runner is loaded lazily',
-  options: {
+  args: {
     name: {
       type: 'string',
       description: 'Name to greet',
@@ -114,7 +114,7 @@ const fullCommandLoader = async () => {
 const lazyFullCommand = lazy(fullCommandLoader, {
   name: 'full',
   description: 'Loads a full command object',
-  options: {
+  args: {
     test: { type: 'boolean' }
   }
 })
@@ -134,7 +134,7 @@ import { cli, lazy } from 'gunshi'
 const asyncJobDefinition = {
   name: 'async-job',
   description: 'Example of a lazy command with an async runner',
-  options: {
+  args: {
     duration: {
       type: 'number',
       short: 'd',
@@ -187,7 +187,7 @@ import type { CommandContext, CommandRunner } from 'gunshi'
 const helloDefinition = define({
   name: 'hello',
   description: 'A type-safe lazy command',
-  options: {
+  args: {
     name: {
       type: 'string',
       description: 'Name to greet',
@@ -197,19 +197,19 @@ const helloDefinition = define({
   // No 'run' needed in definition
 })
 
-type HelloOptions = NonNullable<typeof helloDefinition.options>
+type HelloArgs = NonNullable<typeof helloDefinition.args>
 
 // Define the typed loader function
-// It must return a function matching CommandRunner<typeof helloOptions>
-// or a Command<HelloOptions> containing a 'run' function.
-const helloLoader = async (): Promise<CommandRunner<HelloOptions>> => {
+// It must return a function matching CommandRunner<HelloArgs>
+// or a Command<HelloArgs> containing a 'run' function.
+const helloLoader = async (): Promise<CommandRunner<HelloArgs>> => {
   console.log('Loading typed hello runner...')
   // const { run } = await import('./commands/typedHello.js')
   // return run
 
   // Define typed runner inline
-  const run = (ctx: CommandContext<HelloOptions>) => {
-    // ctx.values is properly typed based on helloOptions
+  const run = (ctx: CommandContext<HelloArgs>) => {
+    // ctx.values is properly typed based on HelloArgs
     console.log(`Hello, ${ctx.values.name}! (Typed)`)
   }
   return run

--- a/docs/guide/essentials/type-safe.md
+++ b/docs/guide/essentials/type-safe.md
@@ -23,7 +23,7 @@ import { cli, define } from 'gunshi'
 // Define a command using the `define` function
 const command = define({
   name: 'greet',
-  options: {
+  args: {
     // Define a string option 'name' with a short alias 'n'
     name: {
       type: 'string',
@@ -44,7 +44,7 @@ const command = define({
       description: 'Enable verbose output'
     }
   },
-  // The 'ctx' parameter is automatically typed based on the options
+  // The 'ctx' parameter is automatically typed based on the args
   run: ctx => {
     // `ctx.values` is fully typed!
     const { name, age, verbose } = ctx.values
@@ -75,7 +75,7 @@ await cli(process.argv.slice(2), command)
 With `define`:
 
 - You don't need to import types like `Command` or `CommandContext`.
-- The `ctx` parameter in the `run` function automatically gets the correct type, derived from the `options` definition.
+- The `ctx` parameter in the `run` function automatically gets the correct type, derived from the `args` definition.
 - Accessing `ctx.values.optionName` provides type safety and autocompletion based on the option's `type` and whether it has a `default`.
   - Options without a `default` (like `name`) are typed as `T | undefined`.
   - Options with a `default` (like `age`) are typed simply as `T`.

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typecheck:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "args-tokens": "^0.16.2"
+    "args-tokens": "^0.17.0"
   },
   "devDependencies": {
     "@eslint/markdown": "^6.4.0",

--- a/playground/auto-usage/index.js
+++ b/playground/auto-usage/index.js
@@ -8,8 +8,8 @@ const command = {
   name: 'file-manager',
   description: 'A file management utility with automatic usage generation',
 
-  // Define various types of options with descriptions to showcase auto usage generation
-  options: {
+  // Define various types of arguments with descriptions to showcase auto usage generation
+  args: {
     // String option with short alias
     path: {
       type: 'string',

--- a/playground/bun/index.ts
+++ b/playground/bun/index.ts
@@ -5,7 +5,7 @@ if (import.meta.main) {
   const createCommand = define({
     name: 'create',
     description: 'Create a new resource',
-    options: {
+    args: {
       name: {
         type: 'string',
         short: 'n',
@@ -31,7 +31,7 @@ if (import.meta.main) {
   // Define the main command using define
   const mainCommand = define({
     name: 'main', // This name is internal if subcommands are used
-    options: {
+    args: {
       count: {
         type: 'number',
         short: 'c'

--- a/playground/composable/index.js
+++ b/playground/composable/index.js
@@ -7,7 +7,7 @@ import { cli } from 'gunshi'
 const createCommand = {
   name: 'create',
   description: 'Create a new resource',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -31,7 +31,7 @@ const createCommand = {
 const listCommand = {
   name: 'list',
   description: 'List all resources',
-  options: {
+  args: {
     type: {
       type: 'string',
       short: 't',
@@ -60,7 +60,7 @@ const listCommand = {
 const deleteCommand = {
   name: 'delete',
   description: 'Delete a resource',
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -95,8 +95,8 @@ subCommands.set('delete', deleteCommand)
 const mainCommand = {
   name: 'resource-manager',
   description: 'Manage resources with composable sub-commands',
-  // The main command can have its own options
-  options: {
+  // The main command can have its own arguments
+  args: {
     verbose: {
       type: 'boolean',
       short: 'v',

--- a/playground/custom-usage/index.js
+++ b/playground/custom-usage/index.js
@@ -8,7 +8,7 @@ const command = {
   name: 'task-manager',
   description: 'A task management utility with custom usage generation',
 
-  options: {
+  args: {
     add: {
       type: 'string',
       short: 'a',
@@ -99,10 +99,10 @@ const customUsageRenderer = ctx => {
   lines.push('')
 
   // Add options section with custom formatting
-  if (ctx.options && Object.keys(ctx.options).length > 0) {
+  if (ctx.args && Object.keys(ctx.args).length > 0) {
     lines.push('OPTIONS:')
 
-    for (const [key, option] of Object.entries(ctx.options)) {
+    for (const [key, option] of Object.entries(ctx.args)) {
       const shortFlag = option.short ? `-${option.short}, ` : '    '
       const longFlag = `--${key}`
       const type = `[${option.type}]`

--- a/playground/declarative/index.js
+++ b/playground/declarative/index.js
@@ -9,8 +9,8 @@ const command = {
   name: 'greet',
   description: 'A greeting command with declarative configuration',
 
-  // Command options with descriptions
-  options: {
+  // Command arguments with descriptions
+  args: {
     name: {
       type: 'string',
       short: 'n',
@@ -49,7 +49,7 @@ const command = {
     console.log('\nCommand configuration:')
     console.log('Name:', ctx.name)
     console.log('Description:', ctx.description)
-    console.log('Options:', ctx.options)
+    console.log('Args:', ctx.args)
     console.log('Values:', ctx.values)
   }
 }

--- a/playground/deno/deno.json
+++ b/playground/deno/deno.json
@@ -3,6 +3,6 @@
     "dev": "deno run --watch main.ts"
   },
   "imports": {
-    "@kazupon/gunshi": "jsr:@kazupon/gunshi@^0.10.4"
+    "@kazupon/gunshi": "jsr:@kazupon/gunshi@^0.18.0"
   }
 }

--- a/playground/deno/deno.lock
+++ b/playground/deno/deno.lock
@@ -1,25 +1,25 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@kazupon/gunshi@~0.10.4": "0.10.4",
-    "npm:args-tokens@0.12": "0.12.0"
+    "jsr:@kazupon/gunshi@0.18": "0.18.0",
+    "npm:args-tokens@~0.16.2": "0.16.2"
   },
   "jsr": {
-    "@kazupon/gunshi@0.10.4": {
-      "integrity": "ee836f0b415108363e01a8c90d29f3382a633cfda71a06ccfce0e827983a0010",
+    "@kazupon/gunshi@0.18.0": {
+      "integrity": "abea7d18ff3ccd39c41dc320ea208e25f629b722ca7ea6d92ed5bbdf755e0ffc",
       "dependencies": [
         "npm:args-tokens"
       ]
     }
   },
   "npm": {
-    "args-tokens@0.12.0": {
-      "integrity": "sha512-xWrKvIA8k8z/8X+yvu29oQwBm867i0Rn21KO9BCMtuJ8HiB8TK8ZHCqPLeXabc2FAdRAbOAR/2wMPHqsjXWAaw=="
+    "args-tokens@0.16.2": {
+      "integrity": "sha512-jWJC6T4FjLssDxBPb/05+e/3xt3CkNiZWWNZaWpN5Q4dI7CZDZgO/2WxLM/ippwRnT1jm/ZZ8LSsV73MSwiGEQ=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@kazupon/gunshi@~0.10.4"
+      "jsr:@kazupon/gunshi@0.18"
     ]
   }
 }

--- a/playground/deno/main.ts
+++ b/playground/deno/main.ts
@@ -8,7 +8,7 @@ if (import.meta.main) {
   const createCommand = define({
     name: 'create',
     description: enUS.description,
-    options: {
+    args: {
       name: {
         type: 'string',
         short: 'n',
@@ -45,7 +45,7 @@ if (import.meta.main) {
   const mainCommand = define({
     name: 'main',
     description: 'A CLI application with Deno',
-    options: {
+    args: {
       count: {
         type: 'number',
         short: 'c',

--- a/playground/docs-gen/index.js
+++ b/playground/docs-gen/index.js
@@ -6,7 +6,7 @@ import path from 'node:path'
 const command = {
   name: 'doc-generator',
   description: 'A documentation generator example',
-  options: {
+  args: {
     output: {
       type: 'string',
       short: 'o',

--- a/playground/i18n/index.js
+++ b/playground/i18n/index.js
@@ -8,7 +8,7 @@ import enUS from './locales/en-US.json' with { type: 'json' }
 const command = {
   name: 'greeter',
 
-  options: {
+  args: {
     name: {
       type: 'string',
       short: 'n'

--- a/playground/lazy-async/index.js
+++ b/playground/lazy-async/index.js
@@ -11,7 +11,7 @@ console.log('Starting lazy-async playground CLI...')
 const lazyCommandDefinition = {
   name: 'lazy', // Key for subCommands map
   description: 'A command whose runner is loaded lazily',
-  options: {
+  args: {
     delay: {
       type: 'number',
       short: 'd',
@@ -50,7 +50,7 @@ const lazyCommand = lazy(lazyCommandLoader, lazyCommandDefinition)
 const asyncDataDefinition = {
   name: 'data', // Key for subCommands map
   description: 'A command that loads data asynchronously via its loader',
-  options: {
+  args: {
     id: {
       type: 'number',
       short: 'i',

--- a/playground/modularization-lazy-async/commands/bar/meta.js
+++ b/playground/modularization-lazy-async/commands/bar/meta.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'bar',
   description: 'This is bar command',
-  options: {
+  args: {
     msg: {
       type: 'string',
       short: 'm',

--- a/playground/modularization-lazy-async/commands/foo/meta.js
+++ b/playground/modularization-lazy-async/commands/foo/meta.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: 'foo',
   description: 'This is foo command',
-  options: {
+  args: {
     id: {
       type: 'number',
       short: 'i',

--- a/playground/type-safe-lazy-async/index.ts
+++ b/playground/type-safe-lazy-async/index.ts
@@ -6,7 +6,7 @@ import type { CommandContext, CommandRunner } from 'gunshi'
 const helloDefinition = define({
   name: 'hello',
   description: 'A type-safe lazy command',
-  options: {
+  args: {
     name: {
       type: 'string',
       description: 'Name to greet',
@@ -16,12 +16,12 @@ const helloDefinition = define({
   // No 'run' needed in definition
 })
 
-type HelloOptions = NonNullable<typeof helloDefinition.options>
+type HelloArgs = NonNullable<typeof helloDefinition.args>
 
 // Define the loader function
-// It must return a function matching CommandRunner<HelloOptionsType>
-// or a Command<HelloOptions> containing a 'run' function.
-const helloLoader = async (): Promise<CommandRunner<HelloOptions>> => {
+// It must return a function matching CommandRunner<HelloArgs>
+// or a Command<HelloArgs> containing a 'run' function.
+const helloLoader = async (): Promise<CommandRunner<HelloArgs>> => {
   console.log('Loading typed hello runner...')
   // Simulate loading delay
   await new Promise(resolve => setTimeout(resolve, 500))
@@ -29,8 +29,8 @@ const helloLoader = async (): Promise<CommandRunner<HelloOptions>> => {
   // return run
 
   // Define typed runner inline
-  const run = (ctx: CommandContext<HelloOptions>) => {
-    // ctx.values is properly typed based on helloOptions
+  const run = (ctx: CommandContext<HelloArgs>) => {
+    // ctx.values is properly typed based on HelloArgs
     console.log(`Hello, ${ctx.values.name}! (Typed)`)
   }
   return run

--- a/playground/type-safe/index.ts
+++ b/playground/type-safe/index.ts
@@ -6,7 +6,7 @@ import { cli, define } from 'gunshi'
 const command = define({
   name: 'type-safe-define',
   description: 'Demonstrates type-safe argument parsing with define',
-  options: {
+  args: {
     // Define string option with short alias
     name: {
       type: 'string',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     dependencies:
       args-tokens:
-        specifier: ^0.16.2
-        version: 0.16.2
+        specifier: ^0.17.0
+        version: 0.17.0
     devDependencies:
       '@eslint/markdown':
         specifier: ^6.4.0
@@ -2001,8 +2001,8 @@ packages:
   args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
-  args-tokens@0.16.2:
-    resolution: {integrity: sha512-jWJC6T4FjLssDxBPb/05+e/3xt3CkNiZWWNZaWpN5Q4dI7CZDZgO/2WxLM/ippwRnT1jm/ZZ8LSsV73MSwiGEQ==}
+  args-tokens@0.17.0:
+    resolution: {integrity: sha512-NRpp00rqKOKCBadQYbz2XldBvX2watxVl9EJzPCvVgzPkTLNvtZxQZZ6/4lUAPK13ej0M64syQY190VPfxM60g==}
     engines: {node: '>= 20'}
 
   array-buffer-byte-length@1.0.2:
@@ -6010,7 +6010,7 @@ snapshots:
 
   args-tokenizer@0.3.0: {}
 
-  args-tokens@0.16.2: {}
+  args-tokens@0.17.0: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,7 @@ import { cli } from './cli.ts'
 import { define } from './definition.ts'
 import { renderValidationErrors } from './renderer.ts'
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { Mocked } from 'vitest'
 import type { Command, CommandOptions, CommandRunner, LazyCommand } from './types.ts'
 
@@ -39,7 +39,7 @@ describe('execute command', () => {
   test('entry command with options', async () => {
     const mockFn = vi.fn()
     await cli(['--outDir', 'dist/', 'foo', 'bar'], {
-      options: {
+      args: {
         outDir: {
           type: 'string',
           short: 'f'
@@ -71,7 +71,7 @@ describe('execute command', () => {
     const subCommands = new Map()
     subCommands.set('command1', {
       name: 'command1',
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f'
@@ -81,7 +81,7 @@ describe('execute command', () => {
     })
     subCommands.set('command2', {
       name: 'command2',
-      options: {
+      args: {
         bar: {
           type: 'number',
           short: 'b'
@@ -198,7 +198,7 @@ test('lazy command', async () => {
   }
   command1.commandName = 'command1'
   command1.description = 'command1 description'
-  command1.options = {
+  command1.args = {
     foo: {
       type: 'string',
       short: 'f'
@@ -211,7 +211,7 @@ test('lazy command', async () => {
   const remoteCommand2: Command = {
     name: 'command2',
     description: 'command2 description',
-    options: {
+    args: {
       bar: {
         type: 'string',
         short: 'b'
@@ -270,7 +270,7 @@ describe('auto generate usage', () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
     const renderedUsage = await cli(['-h'], {
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f'
@@ -290,7 +290,7 @@ describe('auto generate usage', () => {
     const renderedUsage = await cli(
       ['-h'],
       {
-        options: {
+        args: {
           foo: {
             type: 'string',
             short: 'f',
@@ -317,28 +317,28 @@ describe('auto generate usage', () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
 
-    const entryOptions = {
+    const entryArgs = {
       foo: {
         type: 'string',
         short: 'f'
       }
-    } satisfies ArgOptions
+    } satisfies Args
     const entry = {
-      options: entryOptions,
+      args: entryArgs,
       run: vi.fn()
-    } satisfies Command<typeof entryOptions>
+    } satisfies Command<typeof entryArgs>
 
-    const command2Options = {
+    const command2Args = {
       bar: {
         type: 'number',
         short: 'b',
         default: 42
       }
-    } satisfies ArgOptions
+    } satisfies Args
     const command2 = {
-      options: command2Options,
+      args: command2Args,
       run: vi.fn()
-    } satisfies Command<typeof command2Options>
+    } satisfies Command<typeof command2Args>
 
     const subCommands = new Map()
     subCommands.set('command2', command2)
@@ -354,37 +354,37 @@ describe('auto generate usage', () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
 
-    const entryOptions = {
+    const entryArgs = {
       foo: {
         type: 'string',
         short: 'f',
         description: 'The foo option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
     const entry = {
-      options: entryOptions,
+      args: entryArgs,
       name: 'command1',
       examples: '# Example 1\n$ gunshi --foo bar\n# Example 2\n$ gunshi -f bar',
       run: vi.fn()
-    } satisfies Command<typeof entryOptions>
+    } satisfies Command<typeof entryArgs>
 
-    const command2Options = {
+    const command2Args = {
       bar: {
         type: 'number',
         short: 'b',
         default: 42,
         description: 'The bar option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
     const command2 = {
-      options: command2Options,
+      args: command2Args,
       name: 'command2',
       examples: '# Example 1\n$ gunshi command2 --bar 42\n# Example 2\n$ gunshi command2 -b 42',
       // run: vi.fn()
       run: ctx => {
         console.log(ctx.values)
       }
-    } satisfies Command<typeof command2Options>
+    } satisfies Command<typeof command2Args>
 
     const subCommands = new Map()
     subCommands.set('command2', command2)
@@ -419,7 +419,7 @@ describe('auto generate usage', () => {
     await cli(
       ['-h'],
       {
-        options: {
+        args: {
           foo: {
             type: 'string',
             short: 'f',
@@ -467,10 +467,10 @@ describe('custom generate usage', () => {
         default: 42,
         description: 'this is baz option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
 
     const entry = {
-      options: entryOptions,
+      args: entryOptions,
       name: 'command1',
       run: vi.fn()
     } satisfies Command<typeof entryOptions>
@@ -490,7 +490,7 @@ describe('custom generate usage', () => {
 
         // render options section
         messages.push('Options:')
-        for (const [key, value] of Object.entries(ctx.options)) {
+        for (const [key, value] of Object.entries(ctx.args)) {
           const description = value.description || ''
           messages.push(
             `  --${key.padEnd(10)} ${`[${value.type}]`.padEnd(12)}`.padEnd(20) + description
@@ -525,7 +525,7 @@ test('usageSilent', async () => {
   const utils = await import('./utils.ts')
   const log = defineMockLog(utils)
 
-  const entryOptions = {
+  const entryArgs = {
     foo: {
       type: 'string',
       short: 'f',
@@ -542,20 +542,20 @@ test('usageSilent', async () => {
       default: 42,
       description: 'this is baz option'
     }
-  } satisfies ArgOptions
+  } satisfies Args
 
   const entry = {
-    options: entryOptions,
+    args: entryArgs,
     name: 'command1',
     run: vi.fn()
-  } satisfies Command<typeof entryOptions>
+  } satisfies Command<typeof entryArgs>
 
   const options = {
     name: 'gunshi',
     description: 'Modern CLI tool',
     version: '0.0.0',
     usageSilent: true
-  } satisfies CommandOptions<typeof entryOptions>
+  } satisfies CommandOptions<typeof entryArgs>
 
   // usage with silent
   const usage = await cli(['-h'], entry, options)
@@ -597,7 +597,7 @@ test('option grouping', async () => {
   const args = ['-sV']
   const mockFn = vi.fn()
   await cli(args, {
-    options: {
+    args: {
       silent: {
         type: 'boolean',
         short: 's'
@@ -617,7 +617,7 @@ test('rest arguments', async () => {
   const args = ['--foo', 'bar', '--', '--baz', 'qux']
   const mockFn = vi.fn()
   await cli(args, {
-    options: {
+    args: {
       foo: {
         type: 'string',
         short: 'f'
@@ -632,7 +632,7 @@ test('rest arguments', async () => {
 test('negatable options', async () => {
   const args = ['dev', '--bar', '--no-foo']
   await cli(args, {
-    options: {
+    args: {
       foo: {
         type: 'boolean',
         negatable: true
@@ -657,22 +657,22 @@ test('enum options', async () => {
   const log = defineMockLog(utils)
 
   // success case
-  const options = {
+  const args = {
     foo: {
       type: 'enum',
       choices: ['a', 'b', 'c']
     }
-  } satisfies ArgOptions
+  } satisfies Args
   const mockFn1 = vi.fn()
   await cli(['--foo', 'a'], {
-    options,
+    args,
     run: mockFn1
   })
   expect(mockFn1.mock.calls[0][0].values).toEqual({ foo: 'a' })
 
   // failure case
   await cli(['--foo', 'z'], {
-    options,
+    args,
     run: vi.fn()
   })
   const stdout = log()
@@ -684,7 +684,7 @@ describe('edge cases', () => {
     const command = define({
       name: 'test',
       description: 'This is a test command',
-      options: {
+      args: {
         description: {
           type: 'string',
           short: 'd',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ export async function cli<A extends Args = Args>(
     throw new Error(`Command not found: ${name || ''}`)
   }
 
-  const args = resolveArgments(command.args)
+  const args = resolveArguments(command.args)
 
   const { values, positionals, rest, error } = resolveArgs(args, tokens, {
     optionGrouping: true
@@ -83,7 +83,7 @@ export async function cli<A extends Args = Args>(
   await command.run(ctx)
 }
 
-function resolveArgments<A extends Args>(options?: A): A {
+function resolveArguments<A extends Args>(options?: A): A {
   return Object.assign(create<A>(), options, COMMON_OPTIONS)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { createCommandContext } from './context.ts'
 import { renderHeader, renderUsage, renderValidationErrors } from './renderer.ts'
 import { create, resolveLazyCommand } from './utils.ts'
 
-import type { ArgOptions, ArgToken } from 'args-tokens'
+import type { Args, ArgToken } from 'args-tokens'
 import type { Command, CommandContext, CommandOptions, CommandRunner } from './types.ts'
 
 /**
@@ -19,12 +19,12 @@ import type { Command, CommandContext, CommandOptions, CommandRunner } from './t
  * @param opts A {@link CommandOptions | command options}
  * @returns A rendered usage or undefined. if you will use {@link CommandOptions.usageSilent} option, it will return rendered usage string.
  */
-export async function cli<Options extends ArgOptions = ArgOptions>(
-  args: string[],
-  entry: Command<Options> | CommandRunner<Options>,
-  opts: CommandOptions<Options> = {}
+export async function cli<A extends Args = Args>(
+  argv: string[],
+  entry: Command<A> | CommandRunner<A>,
+  opts: CommandOptions<A> = {}
 ): Promise<string | undefined> {
-  const tokens = parseArgs(args)
+  const tokens = parseArgs(argv)
 
   const subCommand = getSubCommand(tokens)
   const resolvedCommandOptions = resolveCommandOptions(opts, entry)
@@ -33,18 +33,18 @@ export async function cli<Options extends ArgOptions = ArgOptions>(
     throw new Error(`Command not found: ${name || ''}`)
   }
 
-  const options = resolveArgOptions(command.options)
+  const args = resolveArgments(command.args)
 
-  const { values, positionals, rest, error } = resolveArgs(options, tokens, {
+  const { values, positionals, rest, error } = resolveArgs(args, tokens, {
     optionGrouping: true
   })
   const omitted = !subCommand
   const ctx = await createCommandContext({
-    options,
+    args,
     values,
     positionals,
     rest,
-    args,
+    argv,
     tokens,
     omitted,
     command,
@@ -83,26 +83,26 @@ export async function cli<Options extends ArgOptions = ArgOptions>(
   await command.run(ctx)
 }
 
-function resolveArgOptions<Options extends ArgOptions>(options?: Options): Options {
-  return Object.assign(create<Options>(), options, COMMON_OPTIONS)
+function resolveArgments<A extends Args>(options?: A): A {
+  return Object.assign(create<A>(), options, COMMON_OPTIONS)
 }
 
-function resolveCommandOptions<Options extends ArgOptions>(
-  options: CommandOptions<Options>,
-  entry: Command<Options> | CommandRunner<Options>
-): CommandOptions<Options> {
+function resolveCommandOptions<A extends Args>(
+  options: CommandOptions<A>,
+  entry: Command<A> | CommandRunner<A>
+): CommandOptions<A> {
   const subCommands = new Map(options.subCommands)
   if (typeof entry === 'object' && entry.name && options.subCommands) {
     subCommands.set(entry.name, entry)
   }
   const resolvedOptions = Object.assign(
-    create<CommandOptions<Options>>(),
+    create<CommandOptions<A>>(),
     COMMAND_OPTIONS_DEFAULT,
     options,
     {
       subCommands
     }
-  ) as CommandOptions<Options>
+  ) as CommandOptions<A>
 
   return resolvedOptions
 }
@@ -117,9 +117,7 @@ function getSubCommand(tokens: ArgToken[]): string {
     : ''
 }
 
-async function showUsage<Options extends ArgOptions>(
-  ctx: CommandContext<Options>
-): Promise<string | undefined> {
+async function showUsage<A extends Args>(ctx: CommandContext<A>): Promise<string | undefined> {
   if (ctx.env.renderUsage === null) {
     return
   }
@@ -130,13 +128,11 @@ async function showUsage<Options extends ArgOptions>(
   }
 }
 
-function showVersion<Options extends ArgOptions>(ctx: CommandContext<Options>): void {
+function showVersion<A extends Args>(ctx: CommandContext<A>): void {
   ctx.log(ctx.env.version)
 }
 
-async function showHeader<Options extends ArgOptions>(
-  ctx: CommandContext<Options>
-): Promise<string | undefined> {
+async function showHeader<A extends Args>(ctx: CommandContext<A>): Promise<string | undefined> {
   if (ctx.env.renderHeader === null) {
     return
   }
@@ -148,8 +144,8 @@ async function showHeader<Options extends ArgOptions>(
   }
 }
 
-async function showValidationErrors<Options extends ArgOptions>(
-  ctx: CommandContext<Options>,
+async function showValidationErrors<A extends Args>(
+  ctx: CommandContext<A>,
   error: AggregateError
 ): Promise<void> {
   if (ctx.env.renderValidationErrors === null) {
@@ -159,12 +155,12 @@ async function showValidationErrors<Options extends ArgOptions>(
   ctx.log(await render(ctx, error))
 }
 
-async function resolveCommand<Options extends ArgOptions>(
+async function resolveCommand<A extends Args>(
   sub: string,
-  entry: Command<Options> | CommandRunner<Options>,
-  options: CommandOptions<Options>,
+  entry: Command<A> | CommandRunner<A>,
+  options: CommandOptions<A>,
   needRunResolving: boolean = false
-): Promise<[string | undefined, Command<Options> | undefined]> {
+): Promise<[string | undefined, Command<A> | undefined]> {
   const omitted = !sub
   if (typeof entry === 'function') {
     return [undefined, { run: entry }]
@@ -189,6 +185,6 @@ async function resolveCommand<Options extends ArgOptions>(
   }
 }
 
-function resolveEntryName<Options extends ArgOptions>(entry: Command<Options>): string {
+function resolveEntryName<A extends Args>(entry: Command<A>): string {
   return entry.name || '(anonymous)'
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { CommandOptions } from './types.ts'
 
 /**
@@ -45,7 +45,7 @@ export const COMMON_OPTIONS: CommonOptionType = {
   }
 }
 
-export const COMMAND_OPTIONS_DEFAULT: CommandOptions<ArgOptions> = {
+export const COMMAND_OPTIONS_DEFAULT: CommandOptions<Args> = {
   name: undefined,
   description: undefined,
   version: undefined,

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -11,11 +11,11 @@ import DefaultLocale from './locales/en-US.json' with { type: 'json' }
 import jaLocale from './locales/ja-JP.json' with { type: 'json' }
 import { resolveBuiltInKey, resolveOptionKey } from './utils.ts'
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { Command, CommandResource, CommandResourceFetcher, LazyCommand } from './types.ts'
 
 test('basic', async () => {
-  const options = {
+  const args = {
     foo: {
       type: 'string',
       short: 'f',
@@ -37,28 +37,28 @@ test('basic', async () => {
       negatable: true,
       description: 'this is qux option'
     }
-  } satisfies ArgOptions
+  } satisfies Args
 
   const command = {
     name: 'cmd1',
     description: 'this is cmd1',
-    options,
+    args,
     examples: 'examples',
     run: vi.fn()
-  } satisfies Command<typeof options>
+  } satisfies Command<typeof args>
 
-  const subCommands = new Map<string, Command<ArgOptions> | LazyCommand<ArgOptions>>()
+  const subCommands = new Map<string, Command<Args> | LazyCommand<Args>>()
   subCommands.set('cmd2', { name: 'cmd2', run: vi.fn() })
 
   const mockRenderUsage = vi.fn()
   const mockRenderValidationErrors = vi.fn()
 
   const ctx = await createCommandContext({
-    options,
+    args,
     values: { foo: 'foo', bar: true, baz: 42 },
     positionals: ['bar'],
     rest: [],
-    args: ['bar'],
+    argv: ['bar'],
     tokens: [], // dummy, due to test
     omitted: true,
     command,
@@ -84,7 +84,7 @@ test('basic', async () => {
   expect(ctx).toMatchObject({
     name: 'cmd1',
     description: 'this is cmd1',
-    options: { foo: { type: 'string' } },
+    args: { foo: { type: 'string' } },
     values: { foo: 'foo' },
     positionals: ['bar'],
     omitted: true
@@ -102,11 +102,11 @@ test('basic', async () => {
     renderValidationErrors: mockRenderValidationErrors
   })
 
-  expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual('this is foo option')
-  expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual('this is bar option')
-  expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual('this is baz option')
-  expect(ctx.translate(resolveOptionKey<typeof options>('qux'))).toEqual('this is qux option')
-  expect(ctx.translate(resolveOptionKey<typeof options>('no-qux'))).toEqual('')
+  expect(ctx.translate(resolveOptionKey<typeof args>('foo'))).toEqual('this is foo option')
+  expect(ctx.translate(resolveOptionKey<typeof args>('bar'))).toEqual('this is bar option')
+  expect(ctx.translate(resolveOptionKey<typeof args>('baz'))).toEqual('this is baz option')
+  expect(ctx.translate(resolveOptionKey<typeof args>('qux'))).toEqual('this is qux option')
+  expect(ctx.translate(resolveOptionKey<typeof args>('no-qux'))).toEqual('')
   expect(ctx.translate(resolveBuiltInKey('help'))).toEqual('Display this help message')
   expect(ctx.translate(resolveBuiltInKey('version'))).toEqual('Display this version')
   expect(ctx.translate('examples')).toEqual('examples')
@@ -120,7 +120,7 @@ test('basic', async () => {
   expect(hasPrototype(ctx)).toEqual(false)
   expect(hasPrototype(ctx.env)).toEqual(false)
   // expect(hasPrototype(ctx.options)).toEqual(false)
-  for (const value of Object.values(ctx.options)) {
+  for (const value of Object.values(ctx.args)) {
     expect(hasPrototype(value)).toEqual(false)
   }
   // expect(hasPrototype(ctx.values)).toEqual(false)
@@ -132,8 +132,8 @@ test('basic', async () => {
   expect(Object.isFrozen(ctx)).toEqual(true)
   expect(Object.isFrozen(ctx.env)).toEqual(true)
   expect(Object.isFrozen(ctx.env.subCommands)).toEqual(true)
-  expect(Object.isFrozen(ctx.options)).toEqual(true)
-  for (const value of Object.values(ctx.options)) {
+  expect(Object.isFrozen(ctx.args)).toEqual(true)
+  for (const value of Object.values(ctx.args)) {
     expect(Object.isFrozen(value)).toEqual(true)
   }
   expect(Object.isFrozen(ctx.values)).toEqual(true)
@@ -144,11 +144,11 @@ test('default', async () => {
     run: vi.fn()
   }
   const ctx = await createCommandContext({
-    options: {},
+    args: {},
     values: { foo: 'foo', bar: true, baz: 42 },
     positionals: ['bar'],
     rest: [],
-    args: ['bar'],
+    argv: ['bar'],
     tokens: [], // dummy, due to test
     command,
     omitted: false,
@@ -162,7 +162,7 @@ test('default', async () => {
   expect(ctx).toMatchObject({
     name: undefined,
     description: undefined,
-    options: {},
+    args: {},
     values: { foo: 'foo', bar: true, baz: 42 },
     positionals: ['bar'],
     omitted: false
@@ -190,11 +190,11 @@ describe('translation', () => {
       run: vi.fn()
     }
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
       rest: [],
-      args: ['bar'],
+      argv: ['bar'],
       tokens: [], // dummy, due to test
       command,
       omitted: false,
@@ -223,7 +223,7 @@ describe('translation', () => {
   })
 
   test('basic', async () => {
-    const options = {
+    const args = {
       foo: {
         type: 'string',
         short: 'f',
@@ -239,22 +239,22 @@ describe('translation', () => {
         default: 42,
         description: 'this is baz option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
 
     const command = {
-      options,
+      args,
       name: 'cmd1',
       description: 'this is cmd1',
       examples: 'this is an cmd1 example',
       run: vi.fn()
-    } satisfies Command<ArgOptions>
+    } satisfies Command<Args>
 
     const ctx = await createCommandContext({
-      options,
+      args,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
       rest: [],
-      args: ['bar'],
+      argv: ['bar'],
       tokens: [], // dummy, due to test
       command,
       omitted: false,
@@ -264,15 +264,15 @@ describe('translation', () => {
     // description, options, and examples
     expect(ctx.translate(resolveBuiltInKey('help'))).toEqual(DefaultLocale.help)
     expect(ctx.translate(resolveBuiltInKey('version'))).toEqual(DefaultLocale.version)
-    expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual('this is foo option')
-    expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual('this is bar option')
-    expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual('this is baz option')
+    expect(ctx.translate(resolveOptionKey<typeof args>('foo'))).toEqual('this is foo option')
+    expect(ctx.translate(resolveOptionKey<typeof args>('bar'))).toEqual('this is bar option')
+    expect(ctx.translate(resolveOptionKey<typeof args>('baz'))).toEqual('this is baz option')
     expect(ctx.translate('description')).toEqual('this is cmd1')
     expect(ctx.translate('examples')).toEqual('this is an cmd1 example')
   })
 
   test('load another locale resource', async () => {
-    const options = {
+    const args = {
       foo: {
         type: 'string',
         short: 'f',
@@ -292,7 +292,7 @@ describe('translation', () => {
         type: 'boolean',
         negatable: true
       }
-    } satisfies ArgOptions
+    } satisfies Args
 
     const jaJPResource = {
       description: 'これはコマンド1です',
@@ -303,11 +303,11 @@ describe('translation', () => {
       'Option:no-qux': 'これは qux オプションの否定形です',
       examples: 'これはコマンド1の例です',
       test: 'これはテストです'
-    } satisfies CommandResource<typeof options>
+    } satisfies CommandResource<typeof args>
 
     const loadLocale = 'ja-JP'
 
-    const mockResource = vi.fn<CommandResourceFetcher<typeof options>>().mockImplementation(ctx => {
+    const mockResource = vi.fn<CommandResourceFetcher<typeof args>>().mockImplementation(ctx => {
       if (ctx.locale.toString() === loadLocale) {
         return Promise.resolve(jaJPResource)
       } else {
@@ -317,18 +317,18 @@ describe('translation', () => {
 
     const command = {
       name: 'cmd1',
-      options,
+      args,
       examples: 'this is an cmd1 example',
       run: vi.fn(),
       resource: mockResource
-    } satisfies Command<typeof options>
+    } satisfies Command<typeof args>
 
     const ctx = await createCommandContext({
-      options,
+      args,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
       rest: [],
-      args: ['bar'],
+      argv: ['bar'],
       tokens: [], // dummy, due to test
       command,
       omitted: false,
@@ -347,19 +347,11 @@ describe('translation', () => {
 
     // description, options, and examples
     expect(ctx.translate('description')).toEqual(jaJPResource.description)
-    expect(ctx.translate(resolveOptionKey<typeof options>('foo'))).toEqual(
-      jaJPResource['Option:foo']
-    )
-    expect(ctx.translate(resolveOptionKey<typeof options>('bar'))).toEqual(
-      jaJPResource['Option:bar']
-    )
-    expect(ctx.translate(resolveOptionKey<typeof options>('baz'))).toEqual(
-      jaJPResource['Option:baz']
-    )
-    expect(ctx.translate(resolveOptionKey<typeof options>('qux'))).toEqual(
-      jaJPResource['Option:qux']
-    )
-    expect(ctx.translate(resolveOptionKey<typeof options>('no-qux'))).toEqual(
+    expect(ctx.translate(resolveOptionKey<typeof args>('foo'))).toEqual(jaJPResource['Option:foo'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('bar'))).toEqual(jaJPResource['Option:bar'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('baz'))).toEqual(jaJPResource['Option:baz'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('qux'))).toEqual(jaJPResource['Option:qux'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('no-qux'))).toEqual(
       jaJPResource['Option:no-qux']
     )
     expect(ctx.translate('examples')).toEqual(jaJPResource.examples)
@@ -371,24 +363,24 @@ describe('translation', () => {
 
 describe('translation adapter', () => {
   test('Intl.MessageFormat (MF2)', async () => {
-    const options = {
+    const args = {
       foo: {
         type: 'string',
         short: 'f',
         description: 'this is foo option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
 
     const jaJPResource = {
       description: 'これはコマンド1です',
       'Option:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{$user}'
-    } satisfies CommandResource<typeof options>
+    } satisfies CommandResource<typeof args>
 
     const loadLocale = 'ja-JP'
 
-    const mockResource = vi.fn<CommandResourceFetcher<typeof options>>().mockImplementation(ctx => {
+    const mockResource = vi.fn<CommandResourceFetcher<typeof args>>().mockImplementation(ctx => {
       if (ctx.locale.toString() === loadLocale) {
         return Promise.resolve(jaJPResource)
       } else {
@@ -398,18 +390,18 @@ describe('translation adapter', () => {
 
     const command = {
       name: 'cmd1',
-      options,
+      args,
       examples: 'this is an cmd1 example',
       run: vi.fn(),
       resource: mockResource
-    } satisfies Command<typeof options>
+    } satisfies Command<typeof args>
 
     const ctx = await createCommandContext({
-      options,
+      args,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
       rest: [],
-      args: ['bar'],
+      argv: ['bar'],
       tokens: [], // dummy, due to test
       command,
       omitted: false,
@@ -427,24 +419,24 @@ describe('translation adapter', () => {
   })
 
   test('Intlify Message Format', async () => {
-    const options = {
+    const args = {
       foo: {
         type: 'string',
         short: 'f',
         description: 'this is foo option'
       }
-    } satisfies ArgOptions
+    } satisfies Args
 
     const jaJPResource = {
       description: 'これはコマンド1です',
       'Option:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{user}'
-    } satisfies CommandResource<typeof options>
+    } satisfies CommandResource<typeof args>
 
     const loadLocale = 'ja-JP'
 
-    const mockResource = vi.fn<CommandResourceFetcher<typeof options>>().mockImplementation(ctx => {
+    const mockResource = vi.fn<CommandResourceFetcher<typeof args>>().mockImplementation(ctx => {
       if (ctx.locale.toString() === loadLocale) {
         return Promise.resolve(jaJPResource)
       } else {
@@ -454,18 +446,18 @@ describe('translation adapter', () => {
 
     const command = {
       name: 'cmd1',
-      options,
+      args,
       examples: 'this is an cmd1 example',
       run: vi.fn(),
       resource: mockResource
-    } satisfies Command<typeof options>
+    } satisfies Command<typeof args>
 
     const ctx = await createCommandContext({
-      options,
+      args,
       values: { foo: 'foo', bar: true, baz: 42 },
       positionals: ['bar'],
       rest: [],
-      args: ['bar'],
+      argv: ['bar'],
       tokens: [], // dummy, due to test
       command,
       omitted: false,

--- a/src/definition.test.ts
+++ b/src/definition.test.ts
@@ -7,7 +7,7 @@ test('define', async () => {
   const command = define({
     name: 'test',
     description: 'A test command',
-    options: {
+    args: {
       foo: {
         type: 'string',
         description: 'A string option'
@@ -26,7 +26,7 @@ test('lazy', async () => {
   const test = define({
     name: 'test',
     description: 'A test command',
-    options: {
+    args: {
       foo: {
         type: 'string',
         description: 'A string option'
@@ -43,7 +43,7 @@ test('lazy', async () => {
   expect(testLazy).toBeInstanceOf(Function)
   expect(testLazy.commandName).toBe(test.name)
   expect(testLazy.description).toBe(test.description)
-  expect(testLazy.options).toEqual(test.options)
+  expect(testLazy.args).toEqual(test.args)
 
   await cli(
     ['test', '--foo', 'bar'],

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -14,19 +14,17 @@
  * @license MIT
  */
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { Command, CommandLoader, LazyCommand } from './types.ts'
 
-export type { ArgOptions, ArgOptionSchema, ArgValues } from 'args-tokens'
+export type { Args, ArgSchema, ArgValues } from 'args-tokens'
 
 /**
  * Define a {@link Command | command} with type inference
  * @param definition A {@link Command | command} definition
  * @returns A {@link Command | command} definition with type inference
  */
-export function define<Options extends ArgOptions = ArgOptions>(
-  definition: Command<Options>
-): Command<Options> {
+export function define<A extends Args = Args>(definition: Command<A>): Command<A> {
   return definition
 }
 
@@ -36,16 +34,16 @@ export function define<Options extends ArgOptions = ArgOptions>(
  * @param definition A {@link Command | command} definition
  * @returns A {@link LazyCommand | lazy command} loader
  */
-export function lazy<Options extends ArgOptions = ArgOptions>(
-  loader: CommandLoader<Options>,
-  definition?: Command<Options>
-): LazyCommand<Options> {
+export function lazy<A extends Args = Args>(
+  loader: CommandLoader<A>,
+  definition?: Command<A>
+): LazyCommand<A> {
   if (definition != null) {
-    ;(loader as LazyCommand<Options>).commandName = definition.name
-    ;(loader as LazyCommand<Options>).description = definition.description
-    ;(loader as LazyCommand<Options>).options = definition.options
-    ;(loader as LazyCommand<Options>).examples = definition.examples
-    ;(loader as LazyCommand<Options>).resource = definition.resource
+    ;(loader as LazyCommand<A>).commandName = definition.name
+    ;(loader as LazyCommand<A>).description = definition.description
+    ;(loader as LazyCommand<A>).args = definition.args
+    ;(loader as LazyCommand<A>).examples = definition.examples
+    ;(loader as LazyCommand<A>).resource = definition.resource
   }
   return loader
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -17,7 +17,7 @@
 import { cli } from './cli.ts'
 import { create } from './utils.ts'
 
-import { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { Command, CommandOptions } from './types.ts'
 
 /**
@@ -27,10 +27,10 @@ import type { Command, CommandOptions } from './types.ts'
  * @param opts - A {@link CommandOptions | command options}
  * @returns A rendered usage.
  */
-export async function generate<Options extends ArgOptions = ArgOptions>(
+export async function generate<A extends Args = Args>(
   command: string | null,
-  entry: Command<Options>,
-  opts: CommandOptions<Options> = {}
+  entry: Command<A>,
+  opts: CommandOptions<A> = {}
 ): Promise<string> {
   const args = ['-h']
   if (command != null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export { parseArgs, resolveArgs } from 'args-tokens'
-export type { ArgOptions, ArgOptionSchema, ArgValues } from 'args-tokens'
+export type { Args, ArgSchema, ArgValues } from 'args-tokens'
 export * from './cli.ts'
 export { DEFAULT_LOCALE } from './constants.ts'
 export { define, lazy } from './definition.ts'

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createCommandContext } from './context.ts'
 import { renderHeader, renderUsage, renderValidationErrors } from './renderer.ts'
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { Command, LazyCommand } from './types.ts'
 
 const NOOP = async () => {}
@@ -12,7 +12,7 @@ afterEach(() => {
 })
 
 const SHOW = {
-  options: {
+  args: {
     foo: {
       type: 'string',
       short: 'f',
@@ -46,13 +46,13 @@ const SHOW = {
   description: 'A show command',
   examples: `# Example 1\n$ test --foo bar --bar --baz 42 --qux quux\n# Example 2\n$ test -f bar -b 42 -q quux`,
   run: NOOP
-} as Command<ArgOptions>
+} as Command<Args>
 
-const COMMANDS = new Map<string, Command<ArgOptions> | LazyCommand<ArgOptions>>()
+const COMMANDS = new Map<string, Command<Args> | LazyCommand<Args>>()
 COMMANDS.set('show', SHOW)
 COMMANDS.set('command1', {
   name: 'command1',
-  options: {
+  args: {
     foo: {
       type: 'string',
       short: 'f',
@@ -82,15 +82,15 @@ describe('renderHeader', () => {
     name: 'test',
     description: 'A test command',
     run: NOOP
-  } as Command<ArgOptions>
+  } as Command<Args>
 
   test('basic', async () => {
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: true,
       command,
@@ -107,11 +107,11 @@ describe('renderHeader', () => {
 
   test('no description', async () => {
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: true,
       command,
@@ -127,11 +127,11 @@ describe('renderHeader', () => {
 
   test('no name & no description', async () => {
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: true,
       command,
@@ -143,11 +143,11 @@ describe('renderHeader', () => {
 
   test('no version', async () => {
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: true,
       command,
@@ -165,7 +165,7 @@ describe('renderHeader', () => {
 describe('renderUsage', () => {
   test('basic', async () => {
     const command = {
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f',
@@ -192,13 +192,13 @@ describe('renderUsage', () => {
       description: 'A test command',
       examples: `# Example 1\n$ test --foo bar --bar --baz 42 --qux quux\n# Example 2\n$ test -f bar -b 42 -q quux`,
       run: NOOP
-    } as Command<ArgOptions>
+    } as Command<Args>
     const ctx = await createCommandContext({
-      options: command.options!,
+      args: command.args!,
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: false,
       command,
@@ -220,13 +220,13 @@ describe('renderUsage', () => {
       run: async () => {
         // something here
       }
-    } as Command<ArgOptions>
+    } as Command<Args>
     const ctx = await createCommandContext({
-      options: {},
+      args: {},
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: false,
       command,
@@ -242,7 +242,7 @@ describe('renderUsage', () => {
 
   test('no required options', async () => {
     const command = {
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f',
@@ -262,13 +262,13 @@ describe('renderUsage', () => {
       name: 'test',
       description: 'A test command',
       run: NOOP
-    } as Command<ArgOptions>
+    } as Command<Args>
     const ctx = await createCommandContext({
-      options: command.options!,
+      args: command.args!,
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: false,
       command,
@@ -284,7 +284,7 @@ describe('renderUsage', () => {
 
   test('no examples', async () => {
     const command = {
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f',
@@ -310,13 +310,13 @@ describe('renderUsage', () => {
       name: 'test',
       description: 'A test command',
       run: NOOP
-    } as Command<ArgOptions>
+    } as Command<Args>
     const ctx = await createCommandContext({
-      options: command.options!,
+      args: command.args!,
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: false,
       command,
@@ -332,7 +332,7 @@ describe('renderUsage', () => {
 
   test('enable usageOptionType', async () => {
     const command = {
-      options: {
+      args: {
         foo: {
           type: 'string',
           short: 'f',
@@ -359,13 +359,13 @@ describe('renderUsage', () => {
       description: 'A test command',
       examples: `# Example 1\n$ test --foo bar --bar --baz 42 --qux quux\n# Example 2\n$ test -f bar -b 42 -q quux`,
       run: NOOP
-    } as Command<ArgOptions>
+    } as Command<Args>
     const ctx = await createCommandContext({
-      options: command.options!,
+      args: command.args!,
       values: {},
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       omitted: false,
       command,
@@ -384,12 +384,12 @@ describe('renderUsage', () => {
 
   test('sub commands', async () => {
     const ctx = await createCommandContext({
-      options: SHOW.options!,
+      args: SHOW.args!,
       values: {},
       omitted: true,
       positionals: [],
       rest: [],
-      args: [],
+      argv: [],
       tokens: [], // dummy, due to test
       command: SHOW,
       commandOptions: {
@@ -406,11 +406,11 @@ describe('renderUsage', () => {
 
 test('renderValidationErrors', async () => {
   const ctx = await createCommandContext({
-    options: SHOW.options!,
+    args: SHOW.args!,
     values: {},
     positionals: [],
     rest: [],
-    args: [],
+    argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
     command: SHOW,

--- a/src/renderer/header.ts
+++ b/src/renderer/header.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { CommandContext } from '../types.ts'
 
 /**
@@ -11,8 +11,8 @@ import type { CommandContext } from '../types.ts'
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered header.
  */
-export function renderHeader<Options extends ArgOptions = ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
+export function renderHeader<A extends Args = Args>(
+  ctx: Readonly<CommandContext<A>>
 ): Promise<string> {
   const title = ctx.env.description || ctx.env.name || ''
   return Promise.resolve(

--- a/src/renderer/usage.ts
+++ b/src/renderer/usage.ts
@@ -6,7 +6,7 @@
 import { COMMON_OPTIONS } from '../constants.ts'
 import { create, resolveBuiltInKey, resolveOptionKey } from '../utils.ts'
 
-import type { ArgOptions, ArgOptionSchema } from 'args-tokens'
+import type { Args, ArgSchema } from 'args-tokens'
 import type { Command, CommandContext } from '../types.ts'
 
 const COMMON_OPTIONS_KEYS = Object.keys(COMMON_OPTIONS)
@@ -16,8 +16,8 @@ const COMMON_OPTIONS_KEYS = Object.keys(COMMON_OPTIONS)
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered usage.
  */
-export async function renderUsage<Options extends ArgOptions = ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
+export async function renderUsage<A extends Args = Args>(
+  ctx: Readonly<CommandContext<A>>
 ): Promise<string> {
   const messages: string[] = []
 
@@ -56,8 +56,8 @@ export async function renderUsage<Options extends ArgOptions = ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered options section
  */
-async function renderOptionsSection<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
+async function renderOptionsSection<A extends Args>(
+  ctx: Readonly<CommandContext<A>>
 ): Promise<string[]> {
   const messages: string[] = []
   messages.push(`${ctx.translate(resolveBuiltInKey('OPTIONS'))}:`)
@@ -70,9 +70,7 @@ async function renderOptionsSection<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered examples section
  */
-function renderExamplesSection<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
-): string[] {
+function renderExamplesSection<A extends Args>(ctx: Readonly<CommandContext<A>>): string[] {
   const messages: string[] = []
 
   const resolvedExamples = resolveExamples(ctx)
@@ -91,8 +89,8 @@ function renderExamplesSection<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered usage section
  */
-async function renderUsageSection<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
+async function renderUsageSection<A extends Args>(
+  ctx: Readonly<CommandContext<A>>
 ): Promise<string[]> {
   const messages: string[] = [`${ctx.translate(resolveBuiltInKey('USAGE'))}:`]
   if (ctx.omitted) {
@@ -114,8 +112,8 @@ async function renderUsageSection<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns A rendered commands section
  */
-async function renderCommandsSection<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
+async function renderCommandsSection<A extends Args>(
+  ctx: Readonly<CommandContext<A>>
 ): Promise<string[]> {
   const messages: string[] = [`${ctx.translate(resolveBuiltInKey('COMMANDS'))}:`]
   const loadedCommands = await ctx.loadCommands()
@@ -143,7 +141,7 @@ async function renderCommandsSection<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns The entry command name
  */
-function resolveEntry<Options extends ArgOptions>(ctx: CommandContext<Options>): string {
+function resolveEntry<A extends Args>(ctx: CommandContext<A>): string {
   return ctx.env.name || ctx.translate(resolveBuiltInKey('COMMAND'))
 }
 
@@ -152,9 +150,7 @@ function resolveEntry<Options extends ArgOptions>(ctx: CommandContext<Options>):
  * @param ctx A {@link CommandContext | command context}
  * @returns The sub command name
  */
-function resolveSubCommand<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>
-): string {
+function resolveSubCommand<A extends Args>(ctx: Readonly<CommandContext<A>>): string {
   return ctx.name || ctx.translate(resolveBuiltInKey('SUBCOMMAND'))
 }
 
@@ -163,7 +159,7 @@ function resolveSubCommand<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns resolved command description
  */
-function resolveDescription<Options extends ArgOptions>(ctx: CommandContext<Options>): string {
+function resolveDescription<A extends Args>(ctx: CommandContext<A>): string {
   return ctx.translate('description') || ctx.description || ''
 }
 
@@ -172,12 +168,12 @@ function resolveDescription<Options extends ArgOptions>(ctx: CommandContext<Opti
  * @param ctx A {@link CommandContext | command context}
  * @returns resolved command examples, if not resolved, return empty string
  */
-function resolveExamples<Options extends ArgOptions>(ctx: CommandContext<Options>): string {
+function resolveExamples<A extends Args>(ctx: CommandContext<A>): string {
   const ret = ctx.translate('examples')
   if (ret) {
     return ret
   }
-  const command = ctx.env.subCommands?.get(ctx.name || '') as Command<Options> | undefined
+  const command = ctx.env.subCommands?.get(ctx.name || '') as Command<A> | undefined
   return command?.examples ?? ''
 }
 
@@ -186,9 +182,7 @@ function resolveExamples<Options extends ArgOptions>(ctx: CommandContext<Options
  * @param ctx A {@link CommandContext | command context}
  * @returns True if the command has sub commands
  */
-async function hasCommands<Options extends ArgOptions>(
-  ctx: CommandContext<Options>
-): Promise<boolean> {
+async function hasCommands<A extends Args>(ctx: CommandContext<A>): Promise<boolean> {
   const loadedCommands = await ctx.loadCommands()
   return loadedCommands.length > 1
 }
@@ -198,8 +192,8 @@ async function hasCommands<Options extends ArgOptions>(
  * @param ctx A {@link CommandContext | command context}
  * @returns True if the command has options
  */
-function hasOptions<Options extends ArgOptions>(ctx: CommandContext<Options>): boolean {
-  return !!(ctx.options && Object.keys(ctx.options).length > 0)
+function hasOptions<A extends Args>(ctx: CommandContext<A>): boolean {
+  return !!(ctx.args && Object.keys(ctx.args).length > 0)
 }
 
 /**
@@ -207,8 +201,8 @@ function hasOptions<Options extends ArgOptions>(ctx: CommandContext<Options>): b
  * @param ctx A {@link CommandContext | command context}
  * @returns True if all options have default values
  */
-function hasAllDefaultOptions<Options extends ArgOptions>(ctx: CommandContext<Options>): boolean {
-  return !!(ctx.options && Object.values(ctx.options).every(opt => opt.default))
+function hasAllDefaultOptions<A extends Args>(ctx: CommandContext<A>): boolean {
+  return !!(ctx.args && Object.values(ctx.args).every(arg => arg.default))
 }
 
 /**
@@ -216,7 +210,7 @@ function hasAllDefaultOptions<Options extends ArgOptions>(ctx: CommandContext<Op
  * @param ctx A {@link CommandContext | command context}
  * @returns Options symbols for usage
  */
-function generateOptionsSymbols<Options extends ArgOptions>(ctx: CommandContext<Options>): string {
+function generateOptionsSymbols<A extends Args>(ctx: CommandContext<A>): string {
   return hasOptions(ctx)
     ? hasAllDefaultOptions(ctx)
       ? `[${ctx.translate(resolveBuiltInKey('OPTIONS'))}]`
@@ -224,7 +218,7 @@ function generateOptionsSymbols<Options extends ArgOptions>(ctx: CommandContext<
     : ''
 }
 
-function makeShortLongOptionPair(schema: ArgOptionSchema, name: string): string {
+function makeShortLongOptionPair(schema: ArgSchema, name: string): string {
   let key = `--${name}`
   if (schema.short) {
     key = `-${schema.short}, ${key}`
@@ -237,10 +231,8 @@ function makeShortLongOptionPair(schema: ArgOptionSchema, name: string): string 
  * @param ctx A {@link CommandContext | command context}
  * @returns Options pairs for usage
  */
-function getOptionsPairs<Options extends ArgOptions>(
-  ctx: CommandContext<Options>
-): Record<string, string> {
-  return Object.entries(ctx.options).reduce((acc, [name, value]) => {
+function getOptionsPairs<A extends Args>(ctx: CommandContext<A>): Record<string, string> {
+  return Object.entries(ctx.args).reduce((acc, [name, value]) => {
     let key = makeShortLongOptionPair(value, name)
     if (value.type !== 'boolean') {
       key = value.default ? `${key} [${name}]` : `${key} <${name}>`
@@ -255,29 +247,26 @@ function getOptionsPairs<Options extends ArgOptions>(
 
 const resolveNegatableKey = (key: string): string => key.split('no-')[1]
 
-function resolveNegatableType<Options extends ArgOptions>(
-  key: string,
-  ctx: Readonly<CommandContext<Options>>
-) {
-  return ctx.options[key.startsWith('no-') ? resolveNegatableKey(key) : key].type
+function resolveNegatableType<A extends Args>(key: string, ctx: Readonly<CommandContext<A>>) {
+  return ctx.args[key.startsWith('no-') ? resolveNegatableKey(key) : key].type
 }
 
-function generateDefaultDisplayValue<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>,
-  schema: ArgOptionSchema
+function generateDefaultDisplayValue<A extends Args>(
+  ctx: Readonly<CommandContext<A>>,
+  schema: ArgSchema
 ): string {
   return `${ctx.translate(resolveBuiltInKey('DEFAULT'))}: ${schema.default}`
 }
 
-function resolveDisplayValue<Options extends ArgOptions>(
-  ctx: Readonly<CommandContext<Options>>,
+function resolveDisplayValue<A extends Args>(
+  ctx: Readonly<CommandContext<A>>,
   key: string
 ): string {
   if (COMMON_OPTIONS_KEYS.includes(key)) {
     return ''
   }
 
-  const schema = ctx.options[key]
+  const schema = ctx.args[key]
   if (
     (schema.type === 'boolean' || schema.type === 'number' || schema.type === 'string') &&
     schema.default !== undefined
@@ -302,8 +291,8 @@ function resolveDisplayValue<Options extends ArgOptions>(
  * @param optionsPairs Options pairs for usage
  * @returns Generated options usage
  */
-async function generateOptionsUsage<Options extends ArgOptions>(
-  ctx: CommandContext<Options>,
+async function generateOptionsUsage<A extends Args>(
+  ctx: CommandContext<A>,
   optionsPairs: Record<string, string>
 ): Promise<string> {
   const optionsMaxLength = Math.max(
@@ -321,7 +310,7 @@ async function generateOptionsUsage<Options extends ArgOptions>(
       let rawDesc = ctx.translate(resolveOptionKey(key))
       if (!rawDesc && key.startsWith('no-')) {
         const name = resolveNegatableKey(key)
-        const schema = ctx.options[name]
+        const schema = ctx.args[name]
         const optionKey = makeShortLongOptionPair(schema, name)
         rawDesc = `${ctx.translate(resolveBuiltInKey('NEGATABLE'))} ${optionKey}`
       }

--- a/src/renderer/validation.ts
+++ b/src/renderer/validation.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { CommandContext } from '../types.ts'
 
 /**
@@ -12,8 +12,8 @@ import type { CommandContext } from '../types.ts'
  * @param error An {@link AggregateError} of option in `args-token` validation
  * @returns A rendered validation error.
  */
-export function renderValidationErrors<Options extends ArgOptions = ArgOptions>(
-  _ctx: CommandContext<Options>,
+export function renderValidationErrors<A extends Args = Args>(
+  _ctx: CommandContext<A>,
   error: AggregateError
 ): Promise<string> {
   const messages = [] as string[]

--- a/src/types.test-d.ts
+++ b/src/types.test-d.ts
@@ -2,11 +2,11 @@ import { expectTypeOf, test } from 'vitest'
 import { cli } from './cli.ts'
 import { define } from './definition.ts'
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type { KeyOfArgOptions } from './types.ts'
 
 test('KeyOfArgOptions', () => {
-  const _options = {
+  const _args = {
     foo: {
       type: 'string'
     },
@@ -17,15 +17,15 @@ test('KeyOfArgOptions', () => {
       type: 'boolean',
       negatable: true
     }
-  } satisfies ArgOptions
-  expectTypeOf<KeyOfArgOptions<typeof _options>>().toEqualTypeOf<'foo' | 'bar' | 'baz' | 'no-baz'>()
+  } satisfies Args
+  expectTypeOf<KeyOfArgOptions<typeof _args>>().toEqualTypeOf<'foo' | 'bar' | 'baz' | 'no-baz'>()
 })
 
 test('specified read only value as enum option default', async () => {
   const choices = ['a', 'b'] as const
 
   const command = define({
-    options: {
+    args: {
       foo: {
         type: 'enum',
         choices

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@
 
 import { BUILT_IN_KEY_SEPARATOR, BUILT_IN_PREFIX, OPTION_PREFIX } from './constants.ts'
 
-import type { ArgOptions } from 'args-tokens'
+import type { Args } from 'args-tokens'
 import type {
   Command,
   Commandable,
@@ -16,17 +16,17 @@ import type {
   RemovedIndex
 } from './types.ts'
 
-export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions>(
-  cmd: Commandable<Options>,
+export async function resolveLazyCommand<A extends Args = Args>(
+  cmd: Commandable<A>,
   name?: string | undefined,
   needRunResolving: boolean = false
-): Promise<Command<Options>> {
-  let command: Command<Options> | undefined
+): Promise<Command<A>> {
+  let command: Command<A> | undefined
   if (typeof cmd === 'function') {
-    command = Object.assign(create<Command<Options>>(), {
+    command = Object.assign(create<Command<A>>(), {
       name: cmd.commandName,
       description: cmd.description,
-      options: cmd.options,
+      args: cmd.args,
       examples: cmd.examples,
       resource: cmd.resource
     })
@@ -42,7 +42,7 @@ export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions
         command.run = loaded.run
         command.name = loaded.name
         command.description = loaded.description
-        command.options = loaded.options
+        command.args = loaded.args
         command.examples = loaded.examples
         command.resource = loaded.resource
       } else {
@@ -50,7 +50,7 @@ export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions
       }
     }
   } else {
-    command = Object.assign(create<Command<Options>>(), cmd)
+    command = Object.assign(create<Command<A>>(), cmd)
   }
 
   if (command.name == null && name) {
@@ -61,15 +61,15 @@ export async function resolveLazyCommand<Options extends ArgOptions = ArgOptions
 }
 
 export function resolveBuiltInKey<
-  Key extends string = CommandBuiltinOptionsKeys | CommandBuiltinResourceKeys
->(key: Key): GenerateNamespacedKey<Key> {
+  K extends string = CommandBuiltinOptionsKeys | CommandBuiltinResourceKeys
+>(key: K): GenerateNamespacedKey<K> {
   return `${BUILT_IN_PREFIX}${BUILT_IN_KEY_SEPARATOR}${key}`
 }
 
 export function resolveOptionKey<
-  Options extends ArgOptions = {},
-  Key extends string = KeyOfArgOptions<RemovedIndex<Options>>
->(key: Key): GenerateNamespacedKey<Key, typeof OPTION_PREFIX> {
+  A extends Args = {},
+  K extends string = KeyOfArgOptions<RemovedIndex<A>>
+>(key: K): GenerateNamespacedKey<K, typeof OPTION_PREFIX> {
   return `${OPTION_PREFIX}${BUILT_IN_KEY_SEPARATOR}${key}`
 }
 

--- a/test/fixtures/register.ts
+++ b/test/fixtures/register.ts
@@ -1,6 +1,6 @@
 import type { Command } from '../../src/types.ts'
 
-const options = {
+const args = {
   catalog: {
     type: 'string',
     short: 'c',
@@ -22,10 +22,10 @@ const options = {
   }
 } as const
 
-const command: Command<typeof options> = {
+const command: Command<typeof args> = {
   name: 'register',
   description: 'Register the dependency to the catalog',
-  options,
+  args,
   examples: `# Register the dependency to the catalog:
 generator register --dependency typescript --alias ^5.7.9 --catalog tools`,
   async run(_ctx) {

--- a/test/fixtures/show.ts
+++ b/test/fixtures/show.ts
@@ -1,6 +1,6 @@
 import type { Command } from '../../src/types.ts'
 
-const options = {
+const args = {
   catalog: {
     type: 'boolean',
     short: 'c',
@@ -15,10 +15,10 @@ const options = {
   }
 } as const
 
-const command: Command<typeof options> = {
+const command: Command<typeof args> = {
   name: 'show',
   description: 'Show the catalog and catalogable dependencies (default command)',
-  options,
+  args,
   examples: `# Show the catalog and catalogable dependencies:
 generator  # \`generator\` is equivalent to \`generator show\``,
   async run() {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR is related to breaking changes in args-tokens.
About details, below issue links and copilot reviews

This PR is necessary to support positional arguments

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

- https://github.com/kazupon/args-tokens/pull/83
- #108 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified naming conventions by renaming all command argument-related types and properties from "options" to "args" across the codebase for clarity and consistency.
  - Updated type imports and exports to use "Args" and "ArgSchema" instead of previous types.
  - Adjusted function signatures, interfaces, and test code to reflect the new naming scheme.
- **Chores**
  - Upgraded the "args-tokens" dependency to version "^0.17.0".
  - Disabled Deno integration in VSCode settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->