### PR TITLE
breaking: change translation reserving keys for arguments

### DIFF
--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -162,7 +162,7 @@ To enable a negatable version of a boolean option (e.g., allowing both `--verbos
 
 Without `negatable: true`, only the positive form (e.g., `--verbose`) is recognized, and passing it sets the value to `true`.
 
-The description for the negatable option (e.g., `--no-verbose`) is automatically generated (e.g., "Negatable of --verbose"). You can customize this message using [internationalization resource files](../essentials/internationalization.md) by providing a translation for the specific `Option:no-<optionName>` key (e.g., `Option:no-verbose`).
+The description for the negatable option (e.g., `--no-verbose`) is automatically generated (e.g., "Negatable of --verbose"). You can customize this message using [internationalization resource files](../essentials/internationalization.md) by providing a translation for the specific `arg:no-<optionName>` key (e.g., `arg:no-verbose`).
 
 ### Examples
 

--- a/docs/guide/essentials/internationalization.md
+++ b/docs/guide/essentials/internationalization.md
@@ -37,8 +37,8 @@ const command = {
     if (ctx.locale.toString() === 'ja-JP') {
       return {
         description: '挨拶アプリケーション',
-        'Option:name': '挨拶する相手の名前',
-        'Option:formal': '丁寧な挨拶を使用する',
+        'arg:name': '挨拶する相手の名前',
+        'arg:formal': '丁寧な挨拶を使用する',
         informal_greeting: 'こんにちは',
         formal_greeting: 'はじめまして'
       }
@@ -47,8 +47,8 @@ const command = {
     // Default to English
     return {
       description: 'Greeting application',
-      'Option:name': 'Name to greet',
-      'Option:formal': 'Use formal greeting',
+      'arg:name': 'Name to greet',
+      'arg:formal': 'Use formal greeting',
       informal_greeting: 'Hello',
       formal_greeting: 'Good day'
     }
@@ -153,8 +153,8 @@ Example locale files:
 ```json
 {
   "description": "Greeting application",
-  "Option:name": "Name to greet",
-  "Option:formal": "Use formal greeting",
+  "arg:name": "Name to greet",
+  "arg:formal": "Use formal greeting",
   "informal_greeting": "Hello",
   "formal_greeting": "Good day"
 }
@@ -165,8 +165,8 @@ Example locale files:
 ```json
 {
   "description": "挨拶アプリケーション",
-  "Option:name": "挨拶する相手の名前",
-  "Option:formal": "丁寧な挨拶を使用する",
+  "arg:name": "挨拶する相手の名前",
+  "arg:formal": "丁寧な挨拶を使用する",
   "informal_greeting": "こんにちは",
   "formal_greeting": "はじめまして"
 }
@@ -247,8 +247,8 @@ When defining your localization resources (either directly in the `resource` fun
 
 - **Command Description**: Use the key `description` for the main description of the command.
 - **Examples**: Use the key `examples` for usage examples.
-- **Option Descriptions**: Keys for the descriptions of command options **must** be prefixed with `Option:`. For example, if you have an option named `target`, its description key must be `Option:target`.
-  - **Negatable Option Descriptions**: For boolean options (e.g., `--verbose`), Gunshi automatically generates a description for the negatable version (e.g., `--no-verbose`) using the built-in `NEGATABLE` key (e.g., "Negatable of --verbose"). To provide a custom translation for a specific negatable option, use the pattern `Option:no-<optionName>`, for example, `Option:no-verbose`.
+- **Argument Descriptions**: Keys for the descriptions of command arguments (options and operands) **must** be prefixed with `arg:`. For example, if you have an argument named `target`, its description key must be `arg:target`.
+  - **Negatable Argument Descriptions**: For boolean options (e.g., `--verbose`), Gunshi automatically generates a description for the negatable version (e.g., `--no-verbose`) using the built-in `NEGATABLE` key (e.g., "Negatable of --verbose"). To provide a custom translation for a specific negatable option, use the pattern `arg:no-<optionName>`, for example, `arg:no-verbose`.
 - **Custom Keys**: Any other keys you define for custom translation messages (like greetings, error messages, etc.) do not require a prefix and can be named freely (e.g., `informal_greeting`, `error_file_not_found`).
 - **Built-in Keys**: Keys for built-in functionalities like `help`, `version`, `USAGE`, `OPTIONS`, `EXAMPLES`, `FORMORE`, and the new `NEGATABLE` key are handled by Gunshi's default locales (found in `src/locales`). You can override these by defining them in your resource file (e.g., providing your own translation for `NEGATABLE`).
 
@@ -268,9 +268,9 @@ const command = define({
     return {
       description: 'This is my command.', // No prefix
       examples: '$ my-command --target file.txt', // No prefix
-      'Option:target': 'The target file to process.', // 'Option:' prefix
-      'Option:verbose': 'Enable verbose output.', // 'Option:' prefix
-      'Option:no-verbose': 'Disable verbose logging specifically.', // Optional custom translation for the negatable option
+      'arg:target': 'The target file to process.', // 'arg:' prefix
+      'arg:verbose': 'Enable verbose output.', // 'arg:' prefix
+      'arg:no-verbose': 'Disable verbose logging specifically.', // Optional custom translation for the negatable option
       processing_message: 'Processing target...' // No prefix
     }
   },
@@ -425,8 +425,8 @@ const command = {
     // Show translation information
     console.log('\nTranslation Information:')
     console.log(`Command Description: ${ctx.translate('description')}`)
-    console.log(`Name Option: ${ctx.translate('Option:name')}`)
-    console.log(`Formal Option: ${ctx.translate('Option:formal')}`)
+    console.log(`Name Argument: ${ctx.translate('arg:name')}`)
+    console.log(`Formal Argument: ${ctx.translate('arg:formal')}`)
   }
 }
 
@@ -447,8 +447,8 @@ With locale files:
 ```json
 {
   "description": "Greeting application",
-  "Option:name": "Name to greet",
-  "Option:formal": "Use formal greeting",
+  "arg:name": "Name to greet",
+  "arg:formal": "Use formal greeting",
   "informal_greeting": "Hello",
   "formal_greeting": "Good day"
 }
@@ -459,8 +459,8 @@ With locale files:
 ```json
 {
   "description": "挨拶アプリケーション",
-  "Option:name": "挨拶する相手の名前",
-  "Option:formal": "丁寧な挨拶を使用する",
+  "arg:name": "挨拶する相手の名前",
+  "arg:formal": "丁寧な挨拶を使用する",
   "informal_greeting": "こんにちは",
   "formal_greeting": "はじめまして"
 }

--- a/playground/deno/locales/en-US.json
+++ b/playground/deno/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "description": "create a new resource",
   "examples": "# Create a resource example1\n$ deno run index.ts create --name my-resource --type special",
-  "Option:name": "Name of the resource to create",
-  "Option:type": "Type of resource to create (default: \"default\")"
+  "arg:name": "Name of the resource to create",
+  "arg:type": "Type of resource to create (default: \"default\")"
 }

--- a/playground/deno/locales/ja-JP.json
+++ b/playground/deno/locales/ja-JP.json
@@ -1,6 +1,6 @@
 {
-  "description": "リソースの新規作成",
+  "description": "新しいリソースを作成します",
   "examples": "# リソースの作成例1\n$ deno run index.ts create --name my-resource --type special",
-  "Option:name": "作成するリソースの名前",
-  "Option:type": "作成するリソースのタイプ (デフォルト: \"default\")"
+  "arg:name": "作成するリソースの名前",
+  "arg:type": "作成するリソースのタイプ (デフォルト: \"default\")"
 }

--- a/playground/i18n/index.js
+++ b/playground/i18n/index.js
@@ -51,10 +51,10 @@ const command = {
     console.log(`${greeting}, ${name}!`)
 
     // Show translation information
-    console.log('\nTranslation Information:')
-    console.log(`Command Description: ${ctx.translate('description')}`)
-    console.log(`Name Option: ${ctx.translate('name')}`)
-    console.log(`Formal Option: ${ctx.translate('formal')}`)
+    console.log('\ntranslation information:')
+    console.log(`command description: ${ctx.translate('description')}`)
+    console.log(`name argument: ${ctx.translate('name')}`)
+    console.log(`formal option: ${ctx.translate('formal')}`)
   }
 }
 

--- a/playground/i18n/locales/en-US.json
+++ b/playground/i18n/locales/en-US.json
@@ -1,8 +1,8 @@
 {
   "description": "A greeting application with internationalization support",
   "examples": "# Basic greeting\n$ node index.js --name John\n\n# Formal greeting in Japanese\n$ MY_LOCALE=ja-JP node index.js --name 田中 --formal",
-  "Option:name": "Name to greet",
-  "Option:formal": "Use formal greeting",
+  "arg:name": "Name to greet",
+  "arg:formal": "Use formal greeting",
   "formal_greeting": "Good day",
   "informal_greeting": "Hello"
 }

--- a/playground/i18n/locales/ja-JP.json
+++ b/playground/i18n/locales/ja-JP.json
@@ -1,8 +1,8 @@
 {
-  "description": "国際化対応の挨拶アプリケーション",
+  "description": "国際化対応した挨拶アプリケーション",
   "examples": "# 基本的な挨拶\n$ node index.js --name John\n\n# 日本語での丁寧な挨拶\n$ MY_LOCALE=ja-JP node index.js --name 田中 --formal",
-  "Option:name": "挨拶する名前",
-  "Option:formal": "丁寧な挨拶を使用する",
+  "arg:name": "挨拶する名前",
+  "arg:formal": "丁寧な挨拶を使用する",
   "formal_greeting": "こんにちは",
   "informal_greeting": "やあ"
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const DEFAULT_LOCALE = 'en-US'
 
 export const BUILT_IN_PREFIX = '_'
 
-export const OPTION_PREFIX = 'Option'
+export const OPTION_PREFIX = 'arg'
 
 export const BUILT_IN_KEY_SEPARATOR = ':'
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -296,11 +296,11 @@ describe('translation', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      'Option:foo': 'これは foo オプションです',
-      'Option:bar': 'これは bar オプションです',
-      'Option:baz': 'これは baz オプションです',
-      'Option:qux': 'これは qux オプションです',
-      'Option:no-qux': 'これは qux オプションの否定形です',
+      'arg:foo': 'これは foo オプションです',
+      'arg:bar': 'これは bar オプションです',
+      'arg:baz': 'これは baz オプションです',
+      'arg:qux': 'これは qux オプションです',
+      'arg:no-qux': 'これは qux オプションの否定形です',
       examples: 'これはコマンド1の例です',
       test: 'これはテストです'
     } satisfies CommandResource<typeof args>
@@ -347,12 +347,12 @@ describe('translation', () => {
 
     // description, options, and examples
     expect(ctx.translate('description')).toEqual(jaJPResource.description)
-    expect(ctx.translate(resolveOptionKey<typeof args>('foo'))).toEqual(jaJPResource['Option:foo'])
-    expect(ctx.translate(resolveOptionKey<typeof args>('bar'))).toEqual(jaJPResource['Option:bar'])
-    expect(ctx.translate(resolveOptionKey<typeof args>('baz'))).toEqual(jaJPResource['Option:baz'])
-    expect(ctx.translate(resolveOptionKey<typeof args>('qux'))).toEqual(jaJPResource['Option:qux'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('foo'))).toEqual(jaJPResource['arg:foo'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('bar'))).toEqual(jaJPResource['arg:bar'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('baz'))).toEqual(jaJPResource['arg:baz'])
+    expect(ctx.translate(resolveOptionKey<typeof args>('qux'))).toEqual(jaJPResource['arg:qux'])
     expect(ctx.translate(resolveOptionKey<typeof args>('no-qux'))).toEqual(
-      jaJPResource['Option:no-qux']
+      jaJPResource['arg:no-qux']
     )
     expect(ctx.translate('examples')).toEqual(jaJPResource.examples)
 
@@ -373,7 +373,7 @@ describe('translation adapter', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      'Option:foo': 'これは foo オプションです',
+      'arg:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{$user}'
     } satisfies CommandResource<typeof args>
@@ -412,8 +412,8 @@ describe('translation adapter', () => {
       }
     })
 
-    const mf1 = new MessageFormat('ja-JP', jaJPResource['Option:foo'])
-    expect(ctx.translate('Option:foo')).toEqual(mf1.format())
+    const mf1 = new MessageFormat('ja-JP', jaJPResource['arg:foo'])
+    expect(ctx.translate('arg:foo')).toEqual(mf1.format())
     const mf2 = new MessageFormat('ja-JP', jaJPResource.user)
     expect(ctx.translate('user', { user: 'kazupon' })).toEqual(mf2.format({ user: 'kazupon' }))
   })
@@ -429,7 +429,7 @@ describe('translation adapter', () => {
 
     const jaJPResource = {
       description: 'これはコマンド1です',
-      'Option:foo': 'これは foo オプションです',
+      'arg:foo': 'これは foo オプションです',
       examples: 'これはコマンド1の例です',
       user: 'こんにちは、{user}'
     } satisfies CommandResource<typeof args>
@@ -468,7 +468,7 @@ describe('translation adapter', () => {
       }
     })
 
-    expect(ctx.translate('Option:foo')).toEqual(jaJPResource['Option:foo'])
+    expect(ctx.translate('arg:foo')).toEqual(jaJPResource['arg:foo'])
     expect(ctx.translate('user', { user: 'kazupon' })).toEqual(`こんにちは、kazupon`)
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to use the new "arg:" prefix for command argument translation keys, replacing the previous "Option:" prefix in all relevant guides and examples.

- **Style**
  - Standardized localization key naming conventions across all locale files by switching from "Option:" to "arg:" for command argument descriptions.
  - Minor improvements to Japanese localization phrasing for clarity.
  - Adjusted console output labels to lowercase and refined wording for translation information display.

- **Tests**
  - Updated test cases to reflect the new "arg:" prefix in translation keys, ensuring consistency with the revised naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->