### PR TITLE
feat!: entry command lazy loading

### DIFF
--- a/docs/guide/advanced/documentation-generation.md
+++ b/docs/guide/advanced/documentation-generation.md
@@ -53,7 +53,7 @@ await main()
 The `generate` function takes three parameters:
 
 - `command`: The command name to generate documentation for, or `null` for the default command
-- `entry`: The command object or function
+- `entry`: The command object or lazy command function
 - `opts`: Command options (name, version, description, etc.)
 
 ## Generating Documentation for Multiple Commands

--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -223,7 +223,7 @@ The `run` function receives a command context object (`ctx`) with:
 - `tokens`: The raw tokens parsed by `args-tokens`.
 - `omitted`: A boolean indicating if the command was run without specifying a subcommand name.
 - `command`: The resolved command definition object itself.
-- `commandOptions`: The resolved command options passed to `cli`.
+- `cliOptions`: The resolved CLI options passed to `cli`.
 - `name`: The name of the _currently executing_ command.
 - `description`: The description of the _currently executing_ command.
 - `env`: The command environment settings (version, logger, renderers, etc.).

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -273,14 +273,14 @@ test('lazy command', async () => {
     },
     run: mockCommand2
   }
-  const command2 = () => {
+  const command2 = lazy(() => {
     return new Promise<Command>(resolve => {
       setTimeout(() => {
         resolve(remoteCommand2)
       }, 5)
     })
-  }
-  subCommands.set(command2.name, command2)
+  }, remoteCommand2)
+  subCommands.set(command2.commandName, command2)
 
   // regularly load command
   const command3 = {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6,7 +6,7 @@ import { renderValidationErrors } from './renderer.ts'
 
 import type { Args } from 'args-tokens'
 import type { Mocked } from 'vitest'
-import type { Command, CommandOptions, CommandRunner, LazyCommand } from './types.ts'
+import type { CliOptions, Command, CommandRunner, LazyCommand } from './types.ts'
 
 afterEach(() => {
   vi.resetAllMocks()
@@ -560,7 +560,7 @@ describe('custom generate usage', () => {
         const msg = `* ${await renderValidationErrors(ctx, error)} *`
         return ['*'.repeat(msg.length), msg, '*'.repeat(msg.length)].join('\n')
       }
-    } satisfies CommandOptions<typeof entryOptions>
+    } satisfies CliOptions<typeof entryOptions>
 
     // usage
     await cli(['-h'], entry, options)
@@ -609,7 +609,7 @@ test('usageSilent', async () => {
     description: 'Modern CLI tool',
     version: '0.0.0',
     usageSilent: true
-  } satisfies CommandOptions<typeof entryArgs>
+  } satisfies CliOptions<typeof entryArgs>
 
   // usage with silent
   const usage = await cli(['-h'], entry, options)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Args } from 'args-tokens'
-import type { CommandOptions } from './types.ts'
+import type { CliOptions } from './types.ts'
 
 /**
  * The default locale string, which format is BCP 47 language tag.
@@ -45,7 +45,7 @@ export const COMMON_ARGS: CommonArgType = {
   }
 }
 
-export const COMMAND_OPTIONS_DEFAULT: CommandOptions<Args> = {
+export const COMMAND_OPTIONS_DEFAULT: CliOptions<Args> = {
   name: undefined,
   description: undefined,
   version: undefined,

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -63,7 +63,7 @@ test('basic', async () => {
     omitted: true,
     callMode: 'entry',
     command,
-    commandOptions: {
+    cliOptions: {
       cwd: '/path/to/cmd1',
       description: 'this is command line',
       version: '0.0.0',
@@ -154,7 +154,7 @@ test('default', async () => {
     command,
     omitted: false,
     callMode: 'entry',
-    commandOptions: {}
+    cliOptions: {}
   })
 
   /**
@@ -201,7 +201,7 @@ describe('translation', () => {
       command,
       omitted: false,
       callMode: 'entry',
-      commandOptions: {}
+      cliOptions: {}
     })
 
     // locale en-US
@@ -262,7 +262,7 @@ describe('translation', () => {
       command,
       omitted: false,
       callMode: 'entry',
-      commandOptions: {}
+      cliOptions: {}
     })
 
     // description, options, and examples
@@ -337,7 +337,7 @@ describe('translation', () => {
       command,
       omitted: false,
       callMode: 'entry',
-      commandOptions: {
+      cliOptions: {
         description: 'this is cmd1',
         locale: new Intl.Locale(loadLocale)
       }
@@ -409,7 +409,7 @@ describe('translation adapter', () => {
       command,
       omitted: false,
       callMode: 'entry',
-      commandOptions: {
+      cliOptions: {
         description: 'this is cmd1',
         locale: new Intl.Locale(loadLocale),
         translationAdapterFactory: createTranslationAdapterForMessageFormat2
@@ -466,7 +466,7 @@ describe('translation adapter', () => {
       command,
       omitted: false,
       callMode: 'entry',
-      commandOptions: {
+      cliOptions: {
         description: 'this is cmd1',
         locale: new Intl.Locale(loadLocale),
         translationAdapterFactory: createTranslationAdapterForIntlifyMessageFormat

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,19 +18,24 @@ import { cli } from './cli.ts'
 import { create } from './utils.ts'
 
 import type { Args } from 'args-tokens'
-import type { Command, CommandOptions } from './types.ts'
+import type { CliOptions, Command, LazyCommand } from './types.ts'
+
+/**
+ * generate options of `generate` function.
+ */
+export type GenerateOptions<A extends Args = Args> = CliOptions<A>
 
 /**
  * Generate the command usage.
  * @param command - usage generate command, if you want to generate the usage of the default command where there are target commands and sub-commands, specify `null`.
  * @param entry - A {@link Command | entry command}
- * @param opts - A {@link CommandOptions | command options}
+ * @param options - A {@link CliOptions | cli options}
  * @returns A rendered usage.
  */
 export async function generate<A extends Args = Args>(
   command: string | null,
-  entry: Command<A>,
-  opts: CommandOptions<A> = {}
+  entry: Command<A> | LazyCommand<A>,
+  options: GenerateOptions<A> = {}
 ): Promise<string> {
   const args = ['-h']
   if (command != null) {
@@ -40,7 +45,7 @@ export async function generate<A extends Args = Args>(
     (await cli(
       args,
       entry,
-      Object.assign(create<CommandOptions>(), opts, { usageSilent: true, __proto__: null })
+      Object.assign(create<GenerateOptions<A>>(), options, { usageSilent: true, __proto__: null })
     )) || ''
   )
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -45,7 +45,11 @@ export async function generate<A extends Args = Args>(
     (await cli(
       args,
       entry,
-      Object.assign(create<GenerateOptions<A>>(), options, { usageSilent: true, __proto__: null })
+      {
+        ...create<GenerateOptions<A>>(), // default options
+        ...options,                      // caller-supplied overrides
+        usageSilent: true                // force silent usage
+      }
     )) || ''
   )
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -42,14 +42,10 @@ export async function generate<A extends Args = Args>(
     args.unshift(command)
   }
   return (
-    (await cli(
-      args,
-      entry,
-      {
-        ...create<GenerateOptions<A>>(), // default options
-        ...options,                      // caller-supplied overrides
-        usageSilent: true                // force silent usage
-      }
-    )) || ''
+    (await cli(args, entry, {
+      ...create<GenerateOptions<A>>(), // default options
+      ...options, // caller-supplied overrides
+      usageSilent: true // force silent usage
+    })) || ''
   )
 }

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -99,7 +99,7 @@ describe('renderHeader', () => {
       omitted: true,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         description: 'this is command line',
         version: '0.0.0',
@@ -121,7 +121,7 @@ describe('renderHeader', () => {
       omitted: true,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -142,7 +142,7 @@ describe('renderHeader', () => {
       omitted: true,
       callMode: 'entry',
       command,
-      commandOptions: { cwd: '/path/to/cmd1' }
+      cliOptions: { cwd: '/path/to/cmd1' }
     })
 
     expect(await renderHeader(ctx)).toEqual('')
@@ -159,7 +159,7 @@ describe('renderHeader', () => {
       omitted: true,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         name: 'cmd1',
         description: 'this is command line'
@@ -211,7 +211,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         name: 'cmd1',
         description: 'this is command line'
@@ -240,7 +240,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -283,7 +283,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -320,7 +320,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -367,7 +367,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -416,7 +416,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1'
@@ -466,7 +466,7 @@ describe('renderUsage', () => {
       omitted: false,
       callMode: 'entry',
       command,
-      commandOptions: {
+      cliOptions: {
         usageOptionType: true,
         leftMargin: 4,
         middleMargin: 12,
@@ -490,7 +490,7 @@ describe('renderUsage', () => {
       argv: [],
       tokens: [], // dummy, due to test
       command: SHOW,
-      commandOptions: {
+      cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',
         name: 'cmd1',
@@ -513,7 +513,7 @@ test('renderValidationErrors', async () => {
     omitted: false,
     callMode: 'entry',
     command: SHOW,
-    commandOptions: {
+    cliOptions: {
       cwd: '/path/to/cmd1',
       version: '0.0.0',
       name: 'cmd1'

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,58 +81,58 @@ export type CommandArgKeys<A extends Args> = GenerateNamespacedKey<
 export interface CommandEnvironment<A extends Args = Args> {
   /**
    * Current working directory.
-   * @see {@link CommandOptions.cwd}
+   * @see {@link CliOptions.cwd}
    */
   cwd: string | undefined
   /**
    * Command name.
-   * @see {@link CommandOptions.name}
+   * @see {@link CliOptions.name}
    */
   name: string | undefined
   /**
    * Command description.
-   * @see {@link CommandOptions.description}
+   * @see {@link CliOptions.description}
    *
    */
   description: string | undefined
   /**
    * Command version.
-   * @see {@link CommandOptions.version}
+   * @see {@link CliOptions.version}
    */
   version: string | undefined
   /**
    * Left margin of the command output.
    * @default 2
-   * @see {@link CommandOptions.leftMargin}
+   * @see {@link CliOptions.leftMargin}
    */
   leftMargin: number
   /**
    * Middle margin of the command output.
    * @default 10
-   * @see {@link CommandOptions.middleMargin}
+   * @see {@link CliOptions.middleMargin}
    */
   middleMargin: number
   /**
    * Whether to display the usage option type.
    * @default false
-   * @see {@link CommandOptions.usageOptionType}
+   * @see {@link CliOptions.usageOptionType}
    */
   usageOptionType: boolean
   /**
    * Whether to display the option value.
    * @default true
-   * @see {@link CommandOptions.usageOptionValue}
+   * @see {@link CliOptions.usageOptionValue}
    */
   usageOptionValue: boolean
   /**
    * Whether to display the command usage.
    * @default false
-   * @see {@link CommandOptions.usageSilent}
+   * @see {@link CliOptions.usageSilent}
    */
   usageSilent: boolean
   /**
    * Sub commands.
-   * @see {@link CommandOptions.subCommands}
+   * @see {@link CliOptions.subCommands}
    */
   subCommands: Map<string, Command<any> | LazyCommand<any>> | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
   /**
@@ -153,9 +153,9 @@ export interface CommandEnvironment<A extends Args = Args> {
 }
 
 /**
- * Command options.
+ * CLI options of `cli` function.
  */
-export interface CommandOptions<A extends Args = Args> {
+export interface CliOptions<A extends Args = Args> {
   /**
    * Current working directory.
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,8 +15,13 @@ import type {
   CommandExamplesFetcher,
   GenerateNamespacedKey,
   KeyOfArgs,
+  LazyCommand,
   RemovedIndex
 } from './types.ts'
+
+export function isLazyCommand<A extends Args = Args>(cmd: unknown): cmd is LazyCommand<A> {
+  return typeof cmd === 'function' && 'commandName' in cmd && !!cmd.commandName
+}
 
 export async function resolveLazyCommand<A extends Args = Args>(
   cmd: Commandable<A>,
@@ -24,7 +29,7 @@ export async function resolveLazyCommand<A extends Args = Args>(
   needRunResolving: boolean = false
 ): Promise<Command<A>> {
   let command: Command<A> | undefined
-  if (typeof cmd === 'function') {
+  if (isLazyCommand<A>(cmd)) {
     command = Object.assign(create<Command<A>>(), {
       name: cmd.commandName,
       description: cmd.description,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified documentation for parameter types in command generation and corrected property names in command context descriptions.

- **New Features**
  - Added a type guard function to accurately identify lazy commands.

- **Refactor**
  - Renamed `CommandOptions` to `CliOptions` throughout the codebase and updated related type names and references for consistency.
  - Improved command resolution and execution logic for better modularity and type safety.
  - Updated function and parameter names for clarity and alignment with new types.

- **Tests**
  - Updated test cases to use the new `cliOptions` property name and adjusted type usage accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->