### PR TITLE
feat: support custom type

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
     "vitepress-plugin-group-icons": "^1.5.5",
     "vitepress-plugin-llms": "^1.3.4",
     "vitest": "^3.1.4",
-    "vue": "^3.5.14"
+    "vue": "^3.5.14",
+    "zod": "^3.25.28"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       vue:
         specifier: ^3.5.14
         version: 3.5.14(typescript@5.8.3)
+      zod:
+        specifier: ^3.25.28
+        version: 3.25.28
 
   playground/auto-usage:
     dependencies:
@@ -4537,8 +4540,8 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
-  zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  zod@3.25.28:
+    resolution: {integrity: sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==}
 
   zodiarg@0.2.1:
     resolution: {integrity: sha512-Vbd8aW709iKX0XbMvjYkyjQYDBvWKedaUWNelcNeO1OxVYJ8jqUpj6lRBoO0PtN3b1DM6Ykz+hf9Y8e9pczmLQ==}
@@ -6984,8 +6987,8 @@ snapshots:
     dependencies:
       ohmyfetch: 0.4.21
       semver: 7.7.1
-      zod: 3.24.3
-      zodiarg: 0.2.1(zod@3.24.3)
+      zod: 3.25.28
+      zodiarg: 0.2.1(zod@3.25.28)
 
   giget@2.0.0:
     dependencies:
@@ -7305,8 +7308,8 @@ snapshots:
       smol-toml: 1.3.3
       strip-json-comments: 5.0.1
       typescript: 5.8.3
-      zod: 3.24.3
-      zod-validation-error: 3.4.0(zod@3.24.3)
+      zod: 3.25.28
+      zod-validation-error: 3.4.0(zod@3.25.28)
 
   kolorist@1.8.0: {}
 
@@ -8090,7 +8093,7 @@ snapshots:
       quick-lru: 7.0.1
       url-join: 5.0.0
       validate-npm-package-name: 5.0.1
-      zod: 3.24.3
+      zod: 3.25.28
       zod-package-json: 1.1.0
 
   query-string@9.1.1:
@@ -9157,16 +9160,16 @@ snapshots:
 
   zod-package-json@1.1.0:
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.28
 
-  zod-validation-error@3.4.0(zod@3.24.3):
+  zod-validation-error@3.4.0(zod@3.25.28):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.28
 
-  zod@3.24.3: {}
+  zod@3.25.28: {}
 
-  zodiarg@0.2.1(zod@3.24.3):
+  zodiarg@0.2.1(zod@3.25.28):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.28
 
   zwitch@2.0.4: {}

--- a/src/renderer/usage.ts
+++ b/src/renderer/usage.ts
@@ -313,7 +313,10 @@ function resolveDisplayValue<A extends Args>(
 
   const schema = ctx.args[key]
   if (
-    (schema.type === 'boolean' || schema.type === 'number' || schema.type === 'string') &&
+    (schema.type === 'boolean' ||
+      schema.type === 'number' ||
+      schema.type === 'string' ||
+      schema.type === 'custom') &&
     schema.default !== undefined
   ) {
     return `(${generateDefaultDisplayValue(ctx, schema)})`


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/kazupon/args-tokens/pull/101

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Documentation now includes detailed guidance and examples for defining custom argument types with user-defined parsing and validation, including usage with libraries like zod.
	- Command-line interface now supports custom argument parsing functions, enabling flexible validation, default values, and multiple value support for custom types.

- **Bug Fixes**
	- Default values are now correctly displayed for custom argument types in help and usage information.

- **Tests**
	- Added comprehensive tests for custom argument parsing, validation errors, default values, and multiple value support.

- **Chores**
	- Added the "zod" library as a new dependency for enhanced schema validation in custom argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->