### PR TITLE
breaking: non-public for command context `log`

### DIFF
--- a/docs/guide/essentials/declarative-configuration.md
+++ b/docs/guide/essentials/declarative-configuration.md
@@ -365,7 +365,6 @@ The `run` function receives a command context object (`ctx`) with:
 - `name`: The name of the _currently executing_ command.
 - `description`: The description of the _currently executing_ command.
 - `env`: The command environment settings (version, logger, renderers, etc.).
-- `log`: Logger function (defaults to `console.log`).
 
 ## CLI Configuration
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,7 @@ export interface CommandContext<A extends Args = Args, V = ArgValues<A>> {
    * If {@link CommandEnvironment.usageSilent} is true, the message is not output.
    * @param message an output message, @see {@link console.log}
    * @param optionalParams an optional parameters, @see {@link console.log}
+   * @internal
    */
   log: (message?: any, ...optionalParams: any[]) => void // eslint-disable-line @typescript-eslint/no-explicit-any
   /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

command contxt `log` was initially intended for use within render functions that users could customize, such as renderHeader. However, as described in the documentation below, render-related functions now return buffered output, which is then output to stdout.
As a result, users no longer need to use `log`, so it will be made private (internal).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

related #148 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove mention of the log property from the command context object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->