### PR TITLE
feat: new usage rendering mechanism

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,8 +33,8 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
         './playground/**',
         './packages/docs/**',
         './**/test/**',
-        './**/src/**.test.ts',
-        './**/src/**.test-d.ts'
+        './**/src/**/*.test.ts',
+        './**/src/**/*.test-d.ts'
       ]
     }
   }),

--- a/packages/gunshi/src/cli.ts
+++ b/packages/gunshi/src/cli.ts
@@ -6,9 +6,9 @@
 import { parseArgs, resolveArgs } from 'args-tokens'
 import { ANONYMOUS_COMMAND_NAME, COMMAND_OPTIONS_DEFAULT } from './constants.ts'
 import { createCommandContext } from './context.ts'
+import { RendererDecorators } from './decorators.ts'
 import { PluginContext } from './plugin.ts'
 import { plugins } from './plugins/index.ts'
-import { renderHeader, renderUsage, renderValidationErrors } from './renderer.ts'
 import { create, isLazyCommand, resolveLazyCommand } from './utils.ts'
 
 import type { Args, ArgToken } from 'args-tokens'
@@ -35,7 +35,8 @@ export async function cli<A extends Args = Args>(
 ): Promise<string | undefined> {
   const cliOptions = resolveCliOptions(options, entry)
 
-  const pluginContext = new PluginContext()
+  const decorators = new RendererDecorators()
+  const pluginContext = new PluginContext(decorators)
   await applyPlugins(pluginContext)
 
   const tokens = parseArgs(argv)
@@ -76,13 +77,13 @@ export async function cli<A extends Args = Args>(
 
   const usageBuffer: string[] = []
 
-  const header = await showHeader(commandContext)
+  const header = await showHeader(commandContext, decorators)
   if (header) {
     usageBuffer.push(header)
   }
 
   if (values.help) {
-    const usage = await showUsage(commandContext)
+    const usage = await showUsage(commandContext, decorators)
     if (usage) {
       usageBuffer.push(usage)
     }
@@ -90,7 +91,7 @@ export async function cli<A extends Args = Args>(
   }
 
   if (error) {
-    await showValidationErrors(commandContext, error)
+    await showValidationErrors(commandContext, error, decorators)
     return
   }
 
@@ -152,11 +153,15 @@ function getSubCommand(tokens: ArgToken[]): string {
     : ''
 }
 
-async function showUsage<A extends Args>(ctx: CommandContext<A>): Promise<string | undefined> {
+async function showUsage<A extends Args>(
+  ctx: CommandContext<A>,
+  decorators: RendererDecorators
+): Promise<string | undefined> {
   if (ctx.env.renderUsage === null) {
     return
   }
-  const usage = await (ctx.env.renderUsage || renderUsage)(ctx)
+  const renderer = ctx.env.renderUsage || decorators.getUsageRenderer()
+  const usage = await renderer(ctx)
   if (usage) {
     ctx.log(usage)
     return usage
@@ -167,11 +172,15 @@ function showVersion<A extends Args>(ctx: CommandContext<A>): void {
   ctx.log(ctx.env.version)
 }
 
-async function showHeader<A extends Args>(ctx: CommandContext<A>): Promise<string | undefined> {
+async function showHeader<A extends Args>(
+  ctx: CommandContext<A>,
+  decorators: RendererDecorators
+): Promise<string | undefined> {
   if (ctx.env.renderHeader === null) {
     return
   }
-  const header = await (ctx.env.renderHeader || renderHeader)(ctx)
+  const renderer = ctx.env.renderHeader || decorators.getHeaderRenderer()
+  const header = await renderer(ctx)
   if (header) {
     ctx.log(header)
     ctx.log()
@@ -181,13 +190,14 @@ async function showHeader<A extends Args>(ctx: CommandContext<A>): Promise<strin
 
 async function showValidationErrors<A extends Args>(
   ctx: CommandContext<A>,
-  error: AggregateError
+  error: AggregateError,
+  decorators: RendererDecorators
 ): Promise<void> {
   if (ctx.env.renderValidationErrors === null) {
     return
   }
-  const render = ctx.env.renderValidationErrors || renderValidationErrors
-  ctx.log(await render(ctx, error))
+  const renderer = ctx.env.renderValidationErrors || decorators.getValidationErrorsRenderer()
+  ctx.log(await renderer(ctx, error))
 }
 
 type ResolveCommandContext<A extends Args = Args> = {

--- a/packages/gunshi/src/cli.ts
+++ b/packages/gunshi/src/cli.ts
@@ -157,6 +157,7 @@ async function showUsage<A extends Args>(
   ctx: CommandContext<A>,
   decorators: RendererDecorators
 ): Promise<string | undefined> {
+  // TODO(kazupon): deprecate cliOptions.renderUsage
   if (ctx.env.renderUsage === null) {
     return
   }
@@ -176,6 +177,7 @@ async function showHeader<A extends Args>(
   ctx: CommandContext<A>,
   decorators: RendererDecorators
 ): Promise<string | undefined> {
+  // TODO(kazupon): deprecate cliOptions.renderHeader
   if (ctx.env.renderHeader === null) {
     return
   }
@@ -193,6 +195,7 @@ async function showValidationErrors<A extends Args>(
   error: AggregateError,
   decorators: RendererDecorators
 ): Promise<void> {
+  // TODO(kazupon): deprecate cliOptions.renderValidationErrors
   if (ctx.env.renderValidationErrors === null) {
     return
   }

--- a/packages/gunshi/src/decorators.test.ts
+++ b/packages/gunshi/src/decorators.test.ts
@@ -1,13 +1,6 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { createMockCommandContext } from '../test/utils.ts'
 import { RendererDecorators } from './decorators.ts'
-
-// Mock the default renderers
-vi.mock('./renderer.ts', () => ({
-  renderHeader: vi.fn().mockResolvedValue('Default Header'),
-  renderUsage: vi.fn().mockResolvedValue('Default Usage'),
-  renderValidationErrors: vi.fn().mockResolvedValue('Default Validation Errors')
-}))
 
 describe('RendererDecorators', () => {
   test('Return default header renderer when no decorators', async () => {
@@ -17,7 +10,7 @@ describe('RendererDecorators', () => {
 
     const result = await renderer(ctx)
 
-    expect(result).toBe('Default Header')
+    expect(result).toBe('')
   })
 
   test('Return default usage renderer when no decorators', async () => {
@@ -27,7 +20,7 @@ describe('RendererDecorators', () => {
 
     const result = await renderer(ctx)
 
-    expect(result).toBe('Default Usage')
+    expect(result).toBe('')
   })
 
   test('Return default validation errors renderer when no decorators', async () => {
@@ -38,7 +31,7 @@ describe('RendererDecorators', () => {
 
     const result = await renderer(ctx, error)
 
-    expect(result).toBe('Default Validation Errors')
+    expect(result).toBe('')
   })
 
   test('Apply single header decorator', async () => {
@@ -53,7 +46,7 @@ describe('RendererDecorators', () => {
     const renderer = decorators.getHeaderRenderer()
     const result = await renderer(ctx)
 
-    expect(result).toBe('[DECORATED] Default Header')
+    expect(result).toBe('[DECORATED] ')
   })
 
   test('Apply multiple decorators in correct order', async () => {
@@ -74,7 +67,7 @@ describe('RendererDecorators', () => {
     const result = await renderer(ctx)
 
     // B is applied last, so it wraps A
-    expect(result).toBe('[B] [A] Default Header [B]')
+    expect(result).toBe('[B] [A]  [B]')
   })
 
   test('Handle async decorators correctly', async () => {
@@ -91,7 +84,7 @@ describe('RendererDecorators', () => {
     const renderer = decorators.getUsageRenderer()
     const result = await renderer(ctx)
 
-    expect(result).toBe('[ASYNC] Default Usage [ASYNC]')
+    expect(result).toBe('[ASYNC]  [ASYNC]')
   })
 
   test('Pass context correctly through decorators', async () => {
@@ -107,7 +100,7 @@ describe('RendererDecorators', () => {
     const renderer = decorators.getHeaderRenderer()
     const result = await renderer(ctx)
 
-    expect(result).toBe('[special-command] Default Header [special-command]')
+    expect(result).toBe('[special-command]  [special-command]')
   })
 
   test('Handle validation errors decorator with error parameter', async () => {
@@ -126,7 +119,7 @@ describe('RendererDecorators', () => {
     const renderer = decorators.getValidationErrorsRenderer()
     const result = await renderer(ctx, error)
 
-    expect(result).toBe('[2 errors] Default Validation Errors [2 errors]')
+    expect(result).toBe('[2 errors]  [2 errors]')
   })
 
   test('Handle decorator that throws error', async () => {
@@ -151,10 +144,8 @@ describe('RendererDecorators', () => {
     const usageRenderer = decorators.getUsageRenderer()
     const validationRenderer = decorators.getValidationErrorsRenderer()
 
-    expect(await headerRenderer(ctx)).toBe('Default Header')
-    expect(await usageRenderer(ctx)).toBe('Default Usage')
-    expect(await validationRenderer(ctx, new AggregateError([], 'validation errors'))).toBe(
-      'Default Validation Errors'
-    )
+    expect(await headerRenderer(ctx)).toBe('')
+    expect(await usageRenderer(ctx)).toBe('')
+    expect(await validationRenderer(ctx, new AggregateError([], 'validation errors'))).toBe('')
   })
 })

--- a/packages/gunshi/src/decorators.test.ts
+++ b/packages/gunshi/src/decorators.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMockCommandContext } from '../test/utils.ts'
+import { RendererDecorators } from './decorators.ts'
+
+// Mock the default renderers
+vi.mock('./renderer.ts', () => ({
+  renderHeader: vi.fn().mockResolvedValue('Default Header'),
+  renderUsage: vi.fn().mockResolvedValue('Default Usage'),
+  renderValidationErrors: vi.fn().mockResolvedValue('Default Validation Errors')
+}))
+
+describe('RendererDecorators', () => {
+  test('Return default header renderer when no decorators', async () => {
+    const decorators = new RendererDecorators()
+    const renderer = decorators.getHeaderRenderer()
+    const ctx = createMockCommandContext()
+
+    const result = await renderer(ctx)
+
+    expect(result).toBe('Default Header')
+  })
+
+  test('Return default usage renderer when no decorators', async () => {
+    const decorators = new RendererDecorators()
+    const renderer = decorators.getUsageRenderer()
+    const ctx = createMockCommandContext()
+
+    const result = await renderer(ctx)
+
+    expect(result).toBe('Default Usage')
+  })
+
+  test('Return default validation errors renderer when no decorators', async () => {
+    const decorators = new RendererDecorators()
+    const renderer = decorators.getValidationErrorsRenderer()
+    const ctx = createMockCommandContext()
+    const error = new AggregateError([new Error('Test error')], 'Validation errors')
+
+    const result = await renderer(ctx, error)
+
+    expect(result).toBe('Default Validation Errors')
+  })
+
+  test('Apply single header decorator', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+
+    decorators.addHeaderDecorator(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[DECORATED] ${result}`
+    })
+
+    const renderer = decorators.getHeaderRenderer()
+    const result = await renderer(ctx)
+
+    expect(result).toBe('[DECORATED] Default Header')
+  })
+
+  test('Apply multiple decorators in correct order', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+
+    decorators.addHeaderDecorator(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[A] ${result}`
+    })
+
+    decorators.addHeaderDecorator(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[B] ${result} [B]`
+    })
+
+    const renderer = decorators.getHeaderRenderer()
+    const result = await renderer(ctx)
+
+    // B is applied last, so it wraps A
+    expect(result).toBe('[B] [A] Default Header [B]')
+  })
+
+  test('Handle async decorators correctly', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+
+    decorators.addUsageDecorator(async (baseRenderer, cmdCtx) => {
+      // Simulate async operation
+      await new Promise(resolve => setTimeout(resolve, 10))
+      const result = await baseRenderer(cmdCtx)
+      return `[ASYNC] ${result} [ASYNC]`
+    })
+
+    const renderer = decorators.getUsageRenderer()
+    const result = await renderer(ctx)
+
+    expect(result).toBe('[ASYNC] Default Usage [ASYNC]')
+  })
+
+  test('Pass context correctly through decorators', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+    ctx.name = 'special-command'
+
+    decorators.addHeaderDecorator(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[${cmdCtx.name}] ${result} [${cmdCtx.name}]`
+    })
+
+    const renderer = decorators.getHeaderRenderer()
+    const result = await renderer(ctx)
+
+    expect(result).toBe('[special-command] Default Header [special-command]')
+  })
+
+  test('Handle validation errors decorator with error parameter', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+    const error = new AggregateError(
+      [new Error('Error 1'), new Error('Error 2')],
+      'Validation errors'
+    )
+
+    decorators.addValidationErrorsDecorator(async (baseRenderer, cmdCtx, err) => {
+      const result = await baseRenderer(cmdCtx, err)
+      return `[${err.errors.length} errors] ${result} [${err.errors.length} errors]`
+    })
+
+    const renderer = decorators.getValidationErrorsRenderer()
+    const result = await renderer(ctx, error)
+
+    expect(result).toBe('[2 errors] Default Validation Errors [2 errors]')
+  })
+
+  test('Handle decorator that throws error', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+
+    decorators.addHeaderDecorator(async () => {
+      throw new Error('Decorator error')
+    })
+
+    const renderer = decorators.getHeaderRenderer()
+
+    await expect(renderer(ctx)).rejects.toThrow('Decorator error')
+  })
+
+  test('Build empty decorator chain correctly', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = createMockCommandContext()
+
+    // Add and then test all three types
+    const headerRenderer = decorators.getHeaderRenderer()
+    const usageRenderer = decorators.getUsageRenderer()
+    const validationRenderer = decorators.getValidationErrorsRenderer()
+
+    expect(await headerRenderer(ctx)).toBe('Default Header')
+    expect(await usageRenderer(ctx)).toBe('Default Usage')
+    expect(await validationRenderer(ctx, new AggregateError([], 'validation errors'))).toBe(
+      'Default Validation Errors'
+    )
+  })
+})

--- a/packages/gunshi/src/decorators.ts
+++ b/packages/gunshi/src/decorators.ts
@@ -5,9 +5,7 @@
 
 import type { CommandContext, RendererDecorator, ValidationErrorsDecorator } from './types.ts'
 
-// Default empty renderers for performance optimization
 const EMPTY_RENDERER = async () => ''
-const EMPTY_VALIDATION_RENDERER = async () => ''
 
 /**
  * Internal class for managing renderer decorators.
@@ -40,11 +38,10 @@ export class RendererDecorators {
 
   getValidationErrorsRenderer(): (ctx: CommandContext, error: AggregateError) => Promise<string> {
     if (this.#validationDecorators.length === 0) {
-      return EMPTY_VALIDATION_RENDERER
+      return EMPTY_RENDERER
     }
 
-    let renderer: (ctx: CommandContext, error: AggregateError) => Promise<string> =
-      EMPTY_VALIDATION_RENDERER
+    let renderer: (ctx: CommandContext, error: AggregateError) => Promise<string> = EMPTY_RENDERER
     for (const decorator of this.#validationDecorators) {
       const previousRenderer = renderer
       renderer = (ctx: CommandContext, error: AggregateError) =>

--- a/packages/gunshi/src/decorators.ts
+++ b/packages/gunshi/src/decorators.ts
@@ -1,0 +1,67 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { renderHeader, renderUsage, renderValidationErrors } from './renderer.ts'
+
+import type { CommandContext, RendererDecorator, ValidationErrorsDecorator } from './types.ts'
+
+/**
+ * Internal class for managing renderer decorators.
+ * This class is not exposed to plugin authors.
+ */
+export class RendererDecorators {
+  #headerDecorators: RendererDecorator<string>[] = []
+  #usageDecorators: RendererDecorator<string>[] = []
+  #validationDecorators: ValidationErrorsDecorator[] = []
+
+  addHeaderDecorator(decorator: RendererDecorator<string>): void {
+    this.#headerDecorators.push(decorator)
+  }
+
+  addUsageDecorator(decorator: RendererDecorator<string>): void {
+    this.#usageDecorators.push(decorator)
+  }
+
+  addValidationErrorsDecorator(decorator: ValidationErrorsDecorator): void {
+    this.#validationDecorators.push(decorator)
+  }
+
+  getHeaderRenderer(): (ctx: CommandContext) => Promise<string> {
+    return this.#buildRenderer(this.#headerDecorators, renderHeader)
+  }
+
+  getUsageRenderer(): (ctx: CommandContext) => Promise<string> {
+    return this.#buildRenderer(this.#usageDecorators, renderUsage)
+  }
+
+  getValidationErrorsRenderer(): (ctx: CommandContext, error: AggregateError) => Promise<string> {
+    if (this.#validationDecorators.length === 0) {
+      return renderValidationErrors
+    }
+
+    let renderer = renderValidationErrors
+    for (const decorator of this.#validationDecorators) {
+      const previousRenderer = renderer
+      renderer = (ctx, error) => decorator(previousRenderer, ctx, error)
+    }
+    return renderer
+  }
+
+  #buildRenderer<T>(
+    decorators: RendererDecorator<T>[],
+    defaultRenderer: (ctx: CommandContext) => Promise<T>
+  ): (ctx: CommandContext) => Promise<T> {
+    if (decorators.length === 0) {
+      return defaultRenderer
+    }
+
+    let renderer = defaultRenderer
+    for (const decorator of decorators) {
+      const previousRenderer = renderer
+      renderer = ctx => decorator(previousRenderer, ctx)
+    }
+    return renderer
+  }
+}

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import { createMockCommandContext } from '../test/utils.ts'
+import { RendererDecorators } from './decorators.ts'
 import { PluginContext } from './plugin.ts'
+
+// Mock the default renderers
+vi.mock('./renderer.ts', () => ({
+  renderHeader: vi.fn().mockResolvedValue('Default Header'),
+  renderUsage: vi.fn().mockResolvedValue('Default Usage'),
+  renderValidationErrors: vi.fn().mockResolvedValue('Default Validation Errors')
+}))
 
 describe('PluginContext#addGlobalOpttion', () => {
   test('basic', () => {
-    const ctx = new PluginContext()
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
     ctx.addGlobalOption('foo', { type: 'string', description: 'foo option' })
     expect(ctx.globalOptions.size).toBe(1)
     expect(ctx.globalOptions.get('foo')).toEqual({
@@ -13,17 +23,74 @@ describe('PluginContext#addGlobalOpttion', () => {
   })
 
   test('name empty', () => {
-    const ctx = new PluginContext()
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
     expect(() => ctx.addGlobalOption('', { type: 'string' })).toThrow(
       'Option name must be a non-empty string'
     )
   })
 
   test('duplicate name', () => {
-    const ctx = new PluginContext()
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
     ctx.addGlobalOption('foo', { type: 'string', description: 'foo option' })
     expect(() => ctx.addGlobalOption('foo', { type: 'string' })).toThrow(
       `Global option 'foo' is already registered`
     )
+  })
+})
+
+describe('PluginContext#decorateHeaderRenderer', () => {
+  test('basic', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
+
+    ctx.decorateHeaderRenderer(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[DECORATED] ${result}`
+    })
+
+    const renderer = decorators.getHeaderRenderer()
+    const mockCtx = createMockCommandContext()
+    const result = await renderer(mockCtx)
+
+    expect(result).toBe('[DECORATED] Default Header')
+  })
+})
+
+describe('PluginContext#decorateUsageRenderer', () => {
+  test('basic', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
+
+    ctx.decorateUsageRenderer(async (baseRenderer, cmdCtx) => {
+      const result = await baseRenderer(cmdCtx)
+      return `[USAGE] ${result}`
+    })
+
+    const renderer = decorators.getUsageRenderer()
+    const mockCtx = createMockCommandContext()
+    const result = await renderer(mockCtx)
+
+    expect(result).toBe('[USAGE] Default Usage')
+  })
+})
+
+describe('PluginContext#decorateValidationErrorsRenderer', () => {
+  test('basic', async () => {
+    const decorators = new RendererDecorators()
+    const ctx = new PluginContext(decorators)
+
+    ctx.decorateValidationErrorsRenderer(async (baseRenderer, cmdCtx, error) => {
+      const result = await baseRenderer(cmdCtx, error)
+      return `[ERROR] ${result}`
+    })
+
+    const renderer = decorators.getValidationErrorsRenderer()
+    const mockCtx = createMockCommandContext()
+    const error = new AggregateError([new Error('Test')], 'Validation failed')
+    const result = await renderer(mockCtx, error)
+
+    expect(result).toBe('[ERROR] Default Validation Errors')
   })
 })

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -1,14 +1,7 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { createMockCommandContext } from '../test/utils.ts'
 import { RendererDecorators } from './decorators.ts'
 import { PluginContext } from './plugin.ts'
-
-// Mock the default renderers
-vi.mock('./renderer.ts', () => ({
-  renderHeader: vi.fn().mockResolvedValue('Default Header'),
-  renderUsage: vi.fn().mockResolvedValue('Default Usage'),
-  renderValidationErrors: vi.fn().mockResolvedValue('Default Validation Errors')
-}))
 
 describe('PluginContext#addGlobalOpttion', () => {
   test('basic', () => {
@@ -54,7 +47,7 @@ describe('PluginContext#decorateHeaderRenderer', () => {
     const mockCtx = createMockCommandContext()
     const result = await renderer(mockCtx)
 
-    expect(result).toBe('[DECORATED] Default Header')
+    expect(result).toBe('[DECORATED] ')
   })
 })
 
@@ -72,7 +65,7 @@ describe('PluginContext#decorateUsageRenderer', () => {
     const mockCtx = createMockCommandContext()
     const result = await renderer(mockCtx)
 
-    expect(result).toBe('[USAGE] Default Usage')
+    expect(result).toBe('[USAGE] ')
   })
 })
 
@@ -91,6 +84,6 @@ describe('PluginContext#decorateValidationErrorsRenderer', () => {
     const error = new AggregateError([new Error('Test')], 'Validation failed')
     const result = await renderer(mockCtx, error)
 
-    expect(result).toBe('[ERROR] Default Validation Errors')
+    expect(result).toBe('[ERROR] ')
   })
 })

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -14,7 +14,8 @@
  */
 
 import type { ArgSchema } from 'args-tokens'
-import type { Awaitable } from './types.ts'
+import type { RendererDecorators } from './decorators.ts'
+import type { Awaitable, RendererDecorator, ValidationErrorsDecorator } from './types.ts'
 
 /**
  * Gunshi plugin, which is a function that receives a PluginContext.
@@ -28,19 +29,25 @@ export type Plugin = (ctx: PluginContext) => Awaitable<void>
  */
 export class PluginContext {
   #globalOptions: Map<string, ArgSchema> = new Map()
+  #decorators: RendererDecorators
 
-  constructor() {
-    // TODO:
+  constructor(decorators: RendererDecorators) {
+    this.#decorators = decorators
   }
 
   /**
-   * Get the global options.
+   * Get the global options
    * @returns A map of global options.
    */
   get globalOptions(): Map<string, ArgSchema> {
     return new Map(this.#globalOptions)
   }
 
+  /**
+   * Add a global option.
+   * @param name An option name
+   * @param schema An {@link ArgSchema} for the option
+   */
   addGlobalOption(name: string, schema: ArgSchema): void {
     if (!name) {
       throw new Error('Option name must be a non-empty string')
@@ -51,5 +58,27 @@ export class PluginContext {
     this.#globalOptions.set(name, schema)
   }
 
-  // TODO: Implement more hooks for plugin context
+  /**
+   * Decorate the header renderer.
+   * @param decorator - A decorator function that wraps the base header renderer.
+   */
+  decorateHeaderRenderer(decorator: RendererDecorator<string>): void {
+    this.#decorators.addHeaderDecorator(decorator)
+  }
+
+  /**
+   * Decorate the usage renderer.
+   * @param decorator - A decorator function that wraps the base usage renderer.
+   */
+  decorateUsageRenderer(decorator: RendererDecorator<string>): void {
+    this.#decorators.addUsageDecorator(decorator)
+  }
+
+  /**
+   * Decorate the validation errors renderer.
+   * @param decorator - A decorator function that wraps the base validation errors renderer.
+   */
+  decorateValidationErrorsRenderer(decorator: ValidationErrorsDecorator): void {
+    this.#decorators.addValidationErrorsDecorator(decorator)
+  }
 }

--- a/packages/gunshi/src/plugins/index.ts
+++ b/packages/gunshi/src/plugins/index.ts
@@ -3,9 +3,10 @@
  * @license MIT
  */
 
+import type { Plugin } from '../plugin.ts'
 import completion from './completion.ts'
 import dryRun from './dryrun.ts'
 import globals from './globals.ts'
-import type { Plugin } from '../plugin.ts'
+import defaultRenderer from './renderer.ts'
 
-export const plugins: Plugin[] = [globals, completion, dryRun]
+export const plugins: Plugin[] = [globals, defaultRenderer, completion, dryRun]

--- a/packages/gunshi/src/plugins/renderer.ts
+++ b/packages/gunshi/src/plugins/renderer.ts
@@ -1,0 +1,21 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { renderHeader } from '../renderer/header.ts'
+import { renderUsage } from '../renderer/usage.ts'
+import { renderValidationErrors } from '../renderer/validation.ts'
+
+import type { PluginContext } from '../plugin.ts'
+
+/**
+ * Default renderer plugin for Gunshi.
+ */
+export default function defaultRenderer(ctx: PluginContext) {
+  ctx.decorateHeaderRenderer(async (_baseRenderer, cmdCtx) => await renderHeader(cmdCtx))
+  ctx.decorateUsageRenderer(async (_baseRenderer, cmdCtx) => await renderUsage(cmdCtx))
+  ctx.decorateValidationErrorsRenderer(
+    async (_baseRenderer, cmdCtx, error) => await renderValidationErrors(cmdCtx, error)
+  )
+}

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -480,3 +480,29 @@ export type LazyCommand<A extends Args = Args> = {
  * Define a command type.
  */
 export type Commandable<A extends Args> = Command<A> | LazyCommand<A>
+
+/**
+ * Renderer decorator type.
+ * A function that wraps a base renderer to add or modify its behavior.
+ * @param baseRenderer The base renderer function to decorate
+ * @param ctx The command context
+ * @returns The decorated result
+ */
+export type RendererDecorator<T> = (
+  baseRenderer: (ctx: CommandContext) => Promise<T>,
+  ctx: CommandContext
+) => Promise<T>
+
+/**
+ * Validation errors renderer decorator type.
+ * A function that wraps a validation errors renderer to add or modify its behavior.
+ * @param baseRenderer The base validation errors renderer function to decorate
+ * @param ctx The command context
+ * @param error The aggregate error containing validation errors
+ * @returns The decorated result
+ */
+export type ValidationErrorsDecorator = (
+  baseRenderer: (ctx: CommandContext, error: AggregateError) => Promise<string>,
+  ctx: CommandContext,
+  error: AggregateError
+) => Promise<string>

--- a/packages/gunshi/test/utils.ts
+++ b/packages/gunshi/test/utils.ts
@@ -10,7 +10,11 @@ import { vi } from 'vitest'
 import { DefaultTranslation } from '../src/translation.ts'
 
 import type { CoreContext, LocaleMessage, LocaleMessageValue } from '@intlify/core'
-import type { TranslationAdapter, TranslationAdapterFactoryOptions } from '../src/types.ts'
+import type {
+  CommandContext,
+  TranslationAdapter,
+  TranslationAdapterFactoryOptions
+} from '../src/types.ts'
 
 export function defineMockLog(utils: typeof import('../src/utils.ts')) {
   const logs: unknown[] = []
@@ -131,5 +135,40 @@ class IntlifyMessageFormatTranslation implements TranslationAdapter {
 
     const ret = translate(this.#context, key, values)
     return typeof ret === 'number' && ret === NOT_REOSLVED ? undefined : (ret as string)
+  }
+}
+
+export function createMockCommandContext(): CommandContext {
+  return {
+    name: 'test-command',
+    description: 'Test command',
+    locale: new Intl.Locale('en-US'),
+    env: {
+      cwd: undefined,
+      name: 'test-app',
+      description: 'Test application',
+      version: '1.0.0',
+      leftMargin: 2,
+      middleMargin: 10,
+      usageOptionType: false,
+      usageOptionValue: true,
+      usageSilent: false,
+      subCommands: undefined,
+      renderUsage: undefined,
+      renderHeader: undefined,
+      renderValidationErrors: undefined
+    },
+    args: {},
+    values: {},
+    positionals: [],
+    rest: [],
+    _: [],
+    tokens: [],
+    omitted: false,
+    callMode: 'entry',
+    log: vi.fn(),
+    loadCommands: vi.fn().mockResolvedValue([]),
+    // eslint-disable-next-line unicorn/prefer-native-coercion-functions, @typescript-eslint/no-explicit-any
+    translate: ((key: any) => String(key)) as CommandContext['translate']
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/gunshi
 
+  playground/renderer-plugin:
+    dependencies:
+      gunshi:
+        specifier: workspace:*
+        version: link:../../packages/gunshi
+
   playground/simple:
     dependencies:
       gunshi:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a flexible system for decorating and customizing CLI output, allowing plugins to modify headers, usage messages, and validation error displays.
  - Added new methods for plugins to register global options and decorate output renderers.
  - Added a default renderer plugin that centralizes header, usage, and validation error rendering logic.

- **Bug Fixes**
  - Improved pattern matching for test files in configuration to ensure proper file inclusion at all directory levels.

- **Tests**
  - Added comprehensive tests for the new decorator system and plugin context enhancements.
  - Provided utilities for creating mock command contexts in tests.

- **Documentation**
  - Expanded type definitions and documentation for new decorator-related types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->