### PR TITLE
refactor: hide commandDecorators getter on plugin context

### DIFF
--- a/packages/gunshi/src/decorators.ts
+++ b/packages/gunshi/src/decorators.ts
@@ -3,7 +3,12 @@
  * @license MIT
  */
 
-import type { CommandContext, RendererDecorator, ValidationErrorsDecorator } from './types.ts'
+import type {
+  CommandContext,
+  CommandDecorator,
+  RendererDecorator,
+  ValidationErrorsDecorator
+} from './types.ts'
 
 const EMPTY_RENDERER = async () => ''
 
@@ -11,10 +16,11 @@ const EMPTY_RENDERER = async () => ''
  * Internal class for managing renderer decorators.
  * This class is not exposed to plugin authors.
  */
-export class RendererDecorators {
+export class Decorators {
   #headerDecorators: RendererDecorator<string>[] = []
   #usageDecorators: RendererDecorator<string>[] = []
   #validationDecorators: ValidationErrorsDecorator[] = []
+  #commandDecorators: CommandDecorator[] = []
 
   addHeaderDecorator(decorator: RendererDecorator<string>): void {
     this.#headerDecorators.push(decorator)
@@ -26,6 +32,14 @@ export class RendererDecorators {
 
   addValidationErrorsDecorator(decorator: ValidationErrorsDecorator): void {
     this.#validationDecorators.push(decorator)
+  }
+
+  addCommandDecorator(decorator: CommandDecorator): void {
+    this.#commandDecorators.push(decorator)
+  }
+
+  get commandDecorators(): readonly CommandDecorator[] {
+    return [...this.#commandDecorators]
   }
 
   getHeaderRenderer(): (ctx: CommandContext) => Promise<string> {

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { createMockCommandContext } from '../test/utils.ts'
-import { RendererDecorators } from './decorators.ts'
+import { Decorators } from './decorators.ts'
 import { PluginContext } from './plugin.ts'
-
-import type { CommandDecorator } from './types.ts'
 
 describe('PluginContext#addGlobalOpttion', () => {
   test('basic', () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
     ctx.addGlobalOption('foo', { type: 'string', description: 'foo option' })
     expect(ctx.globalOptions.size).toBe(1)
@@ -18,7 +16,7 @@ describe('PluginContext#addGlobalOpttion', () => {
   })
 
   test('name empty', () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
     expect(() => ctx.addGlobalOption('', { type: 'string' })).toThrow(
       'Option name must be a non-empty string'
@@ -26,7 +24,7 @@ describe('PluginContext#addGlobalOpttion', () => {
   })
 
   test('duplicate name', () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
     ctx.addGlobalOption('foo', { type: 'string', description: 'foo option' })
     expect(() => ctx.addGlobalOption('foo', { type: 'string' })).toThrow(
@@ -37,7 +35,7 @@ describe('PluginContext#addGlobalOpttion', () => {
 
 describe('PluginContext#decorateHeaderRenderer', () => {
   test('basic', async () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
 
     ctx.decorateHeaderRenderer(async (baseRenderer, cmdCtx) => {
@@ -55,7 +53,7 @@ describe('PluginContext#decorateHeaderRenderer', () => {
 
 describe('PluginContext#decorateUsageRenderer', () => {
   test('basic', async () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
 
     ctx.decorateUsageRenderer(async (baseRenderer, cmdCtx) => {
@@ -73,7 +71,7 @@ describe('PluginContext#decorateUsageRenderer', () => {
 
 describe('PluginContext#decorateValidationErrorsRenderer', () => {
   test('basic', async () => {
-    const decorators = new RendererDecorators()
+    const decorators = new Decorators()
     const ctx = new PluginContext(decorators)
 
     ctx.decorateValidationErrorsRenderer(async (baseRenderer, cmdCtx, error) => {
@@ -87,47 +85,5 @@ describe('PluginContext#decorateValidationErrorsRenderer', () => {
     const result = await renderer(mockCtx, error)
 
     expect(result).toBe('[ERROR] ')
-  })
-})
-
-describe('PluginContext#commandDecorators', () => {
-  const identityDecorator: CommandDecorator = baseRunner => baseRunner
-
-  test('should add command decorator', () => {
-    const decorators = new RendererDecorators()
-    const ctx = new PluginContext(decorators)
-
-    ctx.decorateCommand(identityDecorator)
-
-    expect(ctx.commandDecorators).toHaveLength(1)
-    expect(ctx.commandDecorators[0]).toBe(identityDecorator)
-  })
-
-  test('should add multiple command decorators', () => {
-    const decorators = new RendererDecorators()
-    const ctx = new PluginContext(decorators)
-
-    const decorator1 = identityDecorator
-    const decorator2 = identityDecorator
-
-    ctx.decorateCommand(decorator1)
-    ctx.decorateCommand(decorator2)
-
-    expect(ctx.commandDecorators).toHaveLength(2)
-    expect(ctx.commandDecorators[0]).toBe(decorator1)
-    expect(ctx.commandDecorators[1]).toBe(decorator2)
-  })
-
-  test('should return a copy of decorators array', () => {
-    const decorators = new RendererDecorators()
-    const ctx = new PluginContext(decorators)
-
-    ctx.decorateCommand(identityDecorator)
-
-    const decorators1 = ctx.commandDecorators
-    const decorators2 = ctx.commandDecorators
-
-    expect(decorators1).not.toBe(decorators2)
-    expect(decorators1).toEqual(decorators2)
   })
 })

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -13,8 +13,9 @@
  * @license MIT
  */
 
+import { Decorators } from './decorators.ts'
+
 import type { ArgSchema } from 'args-tokens'
-import type { RendererDecorators } from './decorators.ts'
 import type {
   Awaitable,
   CommandDecorator,
@@ -34,10 +35,9 @@ export type Plugin = (ctx: PluginContext) => Awaitable<void>
  */
 export class PluginContext {
   #globalOptions: Map<string, ArgSchema> = new Map()
-  #decorators: RendererDecorators
-  #commandDecorators: CommandDecorator[] = []
+  #decorators: Decorators
 
-  constructor(decorators: RendererDecorators) {
+  constructor(decorators: Decorators) {
     this.#decorators = decorators
   }
 
@@ -89,19 +89,11 @@ export class PluginContext {
   }
 
   /**
-   * Get the command decorators
-   * @returns The command decorators
-   */
-  get commandDecorators(): readonly CommandDecorator[] {
-    return [...this.#commandDecorators]
-  }
-
-  /**
    * Decorate the command execution.
    * Decorators are applied in reverse order (last registered is executed first).
    * @param decorator - A decorator function that wraps the command runner
    */
   decorateCommand(decorator: CommandDecorator): void {
-    this.#commandDecorators.push(decorator)
+    this.#decorators.addCommandDecorator(decorator)
   }
 }

--- a/packages/gunshi/src/plugins/globals.ts
+++ b/packages/gunshi/src/plugins/globals.ts
@@ -15,7 +15,7 @@ export default function globals(ctx: PluginContext) {
     ctx.addGlobalOption(name, schema)
   }
 
-  // Apply help and version decorators
+  // apply help and version decorators
   ctx.decorateCommand(baseRunner => async ctx => {
     if (ctx.values.version) {
       const version = ctx.env.version || 'unknown'
@@ -32,7 +32,7 @@ export default function globals(ctx: PluginContext) {
       header = await ctx.env.renderHeader(ctx)
       if (header) {
         ctx.log(header)
-        ctx.log() // Empty line after header
+        ctx.log() // empty line after header
         outBuf.push(header)
       }
     }
@@ -49,7 +49,7 @@ export default function globals(ctx: PluginContext) {
       return
     }
 
-    // Normal command execution
+    // normal command execution
     return baseRunner(ctx)
   })
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for managing command decorators directly within the Decorators class, including methods to add and retrieve them.

- **Refactor**
	- Renamed RendererDecorators to Decorators and centralized command decorator management within this class.
	- Updated related components to use the new Decorators class for decorator handling, simplifying internal structure.

- **Tests**
	- Expanded test coverage for command decorator management in the Decorators class.
	- Updated test cases to reflect the new class naming and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->