### PR TITLE
feat: extract load commands as plugin extension

### DIFF
--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -175,7 +175,7 @@ export interface PluginOptions<
 > {
   name: string
 
-  setup: PluginFunction<G>
+  setup?: PluginFunction<G>
   extension?: PluginExtension<T, G>
 }
 
@@ -221,7 +221,7 @@ export function plugin<
   F extends PluginExtension<any, DefaultGunshiParams> // eslint-disable-line @typescript-eslint/no-explicit-any
 >(options: {
   name: N
-  setup: (
+  setup?: (
     ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]: ReturnType<F> } }>>
   ) => Awaitable<void>
   extension: F
@@ -229,7 +229,7 @@ export function plugin<
 
 export function plugin(options: {
   name: string
-  setup: (ctx: PluginContext<DefaultGunshiParams>) => Awaitable<void>
+  setup?: (ctx: PluginContext<DefaultGunshiParams>) => Awaitable<void>
 }): PluginWithoutExtension<DefaultGunshiParams['extensions']>
 
 export function plugin<
@@ -238,7 +238,7 @@ export function plugin<
 >(
   options: {
     name: N
-    setup: (
+    setup?: (
       ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]?: E } }>>
     ) => Awaitable<void>
     extension?: PluginExtension<E, DefaultGunshiParams>
@@ -249,7 +249,11 @@ export function plugin<
 
   // create a wrapper function with properties
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const pluginFn = async (ctx: PluginContext<any>) => await setup(ctx)
+  const pluginFn = async (ctx: PluginContext<any>) => {
+    if (setup) {
+      await setup(ctx)
+    }
+  }
 
   // define the properties
   return Object.defineProperties(pluginFn, {

--- a/packages/gunshi/src/plugins/completion.ts
+++ b/packages/gunshi/src/plugins/completion.ts
@@ -9,8 +9,6 @@ import { plugin } from '../plugin.ts'
  * completion plugin for Gunshi.
  */
 export default plugin({
-  name: 'completion',
-  setup: _ctx => {
-    // TODO(kazupon): Implement dry-run plugin logic
-  }
+  name: 'completion'
+  // TODO(kazupon): Implement completion plugin logic
 })

--- a/packages/gunshi/src/plugins/dryrun.ts
+++ b/packages/gunshi/src/plugins/dryrun.ts
@@ -9,8 +9,6 @@ import { plugin } from '../plugin.ts'
  * dry-run plugin for Gunshi.
  */
 export default plugin({
-  name: 'dry-run',
-  setup: _ctx => {
-    // TODO(kazupon): Implement dry-run plugin logic
-  }
+  name: 'dry-run'
+  // TODO(kazupon): Implement dry-run plugin logic
 })

--- a/packages/gunshi/src/plugins/index.ts
+++ b/packages/gunshi/src/plugins/index.ts
@@ -6,8 +6,9 @@
 import completion from './completion.ts'
 import dryRun from './dryrun.ts'
 import globals from './globals.ts'
+import loader from './loader.ts'
 import defaultRenderer from './renderer.ts'
 
 import type { Plugin } from '../plugin.ts'
 
-export const plugins: Plugin[] = [globals, defaultRenderer, completion, dryRun] as Plugin[]
+export const plugins: Plugin[] = [globals, loader, defaultRenderer, completion, dryRun] as Plugin[]

--- a/packages/gunshi/src/plugins/loader.ts
+++ b/packages/gunshi/src/plugins/loader.ts
@@ -47,8 +47,5 @@ const extension = (ctx: CommandContextCore<DefaultGunshiParams>) => {
  */
 export default plugin({
   name: 'loader',
-  extension,
-  setup: _ctx => {
-    // TODO(kazupon): omit setup logic
-  }
+  extension
 })

--- a/packages/gunshi/src/plugins/loader.ts
+++ b/packages/gunshi/src/plugins/loader.ts
@@ -1,0 +1,54 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { plugin } from '../plugin.ts'
+import { resolveLazyCommand } from '../utils.ts'
+
+import type { Command, CommandContextCore, DefaultGunshiParams, GunshiParams } from '../types.ts'
+
+/**
+ * Command loader plugin context.
+ * This context provides load commands dynamically utils.
+ * These utils are available via `CommandContext.extensions.loader`.
+ */
+export interface LoaderCommandContext {
+  /**
+   * Load commands
+   * @returns A list of commands loaded from the command loader plugin.
+   */
+  loadCommands: <G extends GunshiParams = DefaultGunshiParams>() => Promise<Command<G>[]>
+}
+
+/**
+ * Extension for the command loader plugin.
+ */
+const extension = (ctx: CommandContextCore<DefaultGunshiParams>) => {
+  let cachedCommands: Command<DefaultGunshiParams>[] | undefined
+  return {
+    loadCommands: async <G extends GunshiParams = DefaultGunshiParams>(): Promise<Command<G>[]> => {
+      if (cachedCommands) {
+        return cachedCommands as Command<G>[]
+      }
+
+      const subCommands = [...(ctx.env.subCommands || [])] as [string, Command<G>][]
+      cachedCommands = (await Promise.all(
+        subCommands.map(async ([name, cmd]) => await resolveLazyCommand(cmd, name))
+      )) as Command<DefaultGunshiParams>[]
+
+      return cachedCommands as Command<G>[]
+    }
+  }
+}
+
+/**
+ * command loader plugin for Gunshi.
+ */
+export default plugin({
+  name: 'loader',
+  extension,
+  setup: _ctx => {
+    // TODO(kazupon): omit setup logic
+  }
+})

--- a/packages/gunshi/src/renderer.test.ts
+++ b/packages/gunshi/src/renderer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { createCommandContext } from './context.ts'
+import loaderPlugin from './plugins/loader.ts'
 import { renderHeader, renderUsage, renderValidationErrors } from './renderer.ts'
 
 import type { Args } from 'args-tokens'
@@ -491,6 +492,9 @@ describe('renderUsage', () => {
       argv: [],
       tokens: [], // dummy, due to test
       command: SHOW,
+      extensions: {
+        loader: loaderPlugin.extension
+      },
       cliOptions: {
         cwd: '/path/to/cmd1',
         version: '0.0.0',

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -337,12 +337,6 @@ export interface CommandContext<G extends GunshiParams<any> = DefaultGunshiParam
    */
   log: (message?: any, ...optionalParams: any[]) => void // eslint-disable-line @typescript-eslint/no-explicit-any
   /**
-   * Load sub-commands.
-   * The loaded commands are cached and returned when called again.
-   * @returns loaded commands.
-   */
-  loadCommands: () => Promise<Command<G>[]>
-  /**
    * Translate function.
    * @param key the key to be translated
    * @param values the values to be formatted


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new loader plugin that dynamically loads and caches commands as an extension in the command context.

- **Refactor**
  - Updated command context to handle extensions in a more streamlined way.
  - Changed how commands are loaded, shifting from a direct method to using the loader extension.
  - Made plugin setup functions optional to improve plugin flexibility.
  - Removed setup methods from completion and dry-run plugins for simplification.

- **Bug Fixes**
  - Improved test setup to include the loader extension for more accurate subcommand handling.

- **Documentation**
  - Updated type definitions to reflect the new command loading mechanism and extension structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->