### PR TITLE
refactor: move showValidationErrors to global plugin

### DIFF
--- a/packages/gunshi/src/cli.ts
+++ b/packages/gunshi/src/cli.ts
@@ -74,16 +74,9 @@ export async function cli<G extends GunshiParams = DefaultGunshiParams>(
     callMode,
     command,
     extensions: getPluginExtensions(plugins),
+    validationError: error,
     cliOptions: cliOptions
   })
-
-  // Skip validation if help or version is requested
-  const skipValidation = values.help || values.version
-
-  if (!skipValidation && error) {
-    await showValidationErrors(commandContext, error, decorators)
-    return
-  }
 
   return await executeCommand(command, commandContext, name || '', decorators.commandDecorators)
 }
@@ -167,19 +160,6 @@ function getSubCommand(tokens: ArgToken[]): string {
     firstToken.value
     ? firstToken.value
     : ''
-}
-
-async function showValidationErrors<G extends GunshiParams>(
-  ctx: CommandContext<G>,
-  error: AggregateError,
-  decorators: Decorators<G>
-): Promise<void> {
-  // TODO(kazupon): deprecate cliOptions.renderValidationErrors
-  if (ctx.env.renderValidationErrors === null) {
-    return
-  }
-  const renderer = ctx.env.renderValidationErrors || decorators.getValidationErrorsRenderer()
-  ctx.log(await renderer(ctx, error))
 }
 
 type ResolveCommandContext<G extends GunshiParams = DefaultGunshiParams> = {

--- a/packages/gunshi/src/context.ts
+++ b/packages/gunshi/src/context.ts
@@ -113,6 +113,10 @@ interface CommandContextParams<
    * A command options, which is spicialized from `cli` function
    */
   cliOptions: CliOptions<G>
+  /**
+   * Validation error from argument parsing.
+   */
+  validationError?: AggregateError
 }
 
 /**
@@ -137,7 +141,8 @@ export async function createCommandContext<
   extensions = {} as E,
   cliOptions,
   callMode = 'entry',
-  omitted = false
+  omitted = false,
+  validationError
 }: CommandContextParams<G, V, C, E>): Promise<
   {} extends ExtractExtensions<E>
     ? Readonly<CommandContext<G>>
@@ -231,7 +236,8 @@ export async function createCommandContext<
     tokens,
     toKebab: command.toKebab,
     log: cliOptions.usageSilent ? NOOP : log,
-    translate
+    translate,
+    validationError
   })
 
   /**

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -354,6 +354,11 @@ export interface CommandContext<G extends GunshiParams<any> = DefaultGunshiParam
    *  Command context extensions.
    */
   extensions: keyof G['extensions'] extends never ? undefined : G['extensions']
+  /**
+   * Validation error from argument parsing.
+   * This will be set if argument validation fails during CLI execution.
+   */
+  validationError?: AggregateError
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Validation errors encountered during command execution are now displayed directly as part of the global command lifecycle, providing clearer feedback when argument validation fails.

- **Bug Fixes**
  - Improved handling of validation errors to ensure users are promptly informed of argument parsing issues before command execution proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->