### PR TITLE
feat: plugin dependency

### DIFF
--- a/packages/gunshi/src/cli.ts
+++ b/packages/gunshi/src/cli.ts
@@ -7,7 +7,7 @@ import { parseArgs, resolveArgs } from 'args-tokens'
 import { ANONYMOUS_COMMAND_NAME, COMMAND_OPTIONS_DEFAULT, NOOP } from './constants.ts'
 import { createCommandContext } from './context.ts'
 import { Decorators } from './decorators.ts'
-import { PluginContext } from './plugin.ts'
+import { PluginContext, resolveDependencies } from './plugin.ts'
 import { plugins } from './plugins/index.ts'
 import { create, isLazyCommand, resolveLazyCommand } from './utils.ts'
 
@@ -84,9 +84,10 @@ export async function cli<G extends GunshiParams = DefaultGunshiParams>(
 async function applyPlugins<G extends GunshiParams>(
   pluginContext: PluginContext<G>
 ): Promise<Plugin[]> {
+  const sortedPlugins = resolveDependencies(plugins)
   try {
     // TODO(kazupon): add more user plugins loading logic
-    for (const plugin of plugins) {
+    for (const plugin of sortedPlugins) {
       /**
        * NOTE(kazupon):
        * strictly `Args` are not required for plugin installation.
@@ -99,7 +100,7 @@ async function applyPlugins<G extends GunshiParams>(
     console.error('Error loading plugin:', (error as Error).message)
   }
 
-  return plugins
+  return sortedPlugins
 }
 
 function getCommandArgs<G extends GunshiParams>(cmd?: Command<G> | LazyCommand<G>): G['args'] {

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -3,7 +3,7 @@ import { createMockCommandContext } from '../test/utils.ts'
 import { createCommandContext } from './context.ts'
 import { Decorators } from './decorators.ts'
 import { define } from './definition.ts'
-import { PluginContext, plugin } from './plugin.ts'
+import { PluginContext, plugin, resolveDependencies } from './plugin.ts'
 
 import type { Args } from 'args-tokens'
 import type { Plugin } from './plugin.ts'
@@ -494,5 +494,162 @@ describe('Plugin Extensions Integration', () => {
       hasValues: true,
       hasTranslate: true
     })
+  })
+})
+
+describe('resolveDependencies', () => {
+  test('return plugins in correct order with no dependencies', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({ name: 'b' })
+    const pluginC = plugin({ name: 'c' })
+
+    const result = resolveDependencies([pluginA, pluginB, pluginC])
+
+    expect(result).toEqual([pluginA, pluginB, pluginC])
+  })
+
+  test('resolve simple dependencies', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+    const pluginC = plugin({ name: 'c', dependencies: ['b'] })
+
+    const result = resolveDependencies([pluginC, pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('resolve complex dependencies', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+    const pluginC = plugin({ name: 'c', dependencies: ['a'] })
+    const pluginD = plugin({ name: 'd', dependencies: ['b', 'c'] })
+
+    const result = resolveDependencies([pluginD, pluginC, pluginB, pluginA])
+
+    const names = result.map(p => p.name)
+    expect(names[0]).toBe('a')
+    expect(names.indexOf('b')).toBeGreaterThan(names.indexOf('a'))
+    expect(names.indexOf('c')).toBeGreaterThan(names.indexOf('a'))
+    expect(names.indexOf('d')).toBeGreaterThan(names.indexOf('b'))
+    expect(names.indexOf('d')).toBeGreaterThan(names.indexOf('c'))
+  })
+
+  test('handle plugins with PluginDependency objects', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({
+      name: 'b',
+      dependencies: [{ name: 'a', optional: false }]
+    })
+
+    const result = resolveDependencies([pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b'])
+  })
+
+  test('handle optional dependencies when plugin is missing', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({
+      name: 'b',
+      dependencies: [{ name: 'missing', optional: true }]
+    })
+
+    const result = resolveDependencies([pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['b', 'a'])
+  })
+
+  test('handle optional dependencies when plugin exists', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({
+      name: 'b',
+      dependencies: [{ name: 'a', optional: true }]
+    })
+
+    const result = resolveDependencies([pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b'])
+  })
+
+  test('throw error for missing required dependency', () => {
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+
+    expect(() => resolveDependencies([pluginB])).toThrow('Missing required dependency: a')
+  })
+
+  test('throw error for circular dependency', () => {
+    const pluginA = plugin({ name: 'a', dependencies: ['b'] })
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+
+    expect(() => resolveDependencies([pluginA, pluginB])).toThrow('Circular dependency detected: a')
+  })
+
+  test('throw error for self-dependency', () => {
+    const pluginA = plugin({ name: 'a', dependencies: ['a'] })
+
+    expect(() => resolveDependencies([pluginA])).toThrow('Circular dependency detected: a')
+  })
+
+  test('handle plugins without names', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = {} as Plugin
+    const pluginC = plugin({ name: 'c', dependencies: ['a'] })
+
+    const result = resolveDependencies([pluginB, pluginC, pluginA])
+
+    expect(result.filter(p => p.name).map(p => p.name)).toEqual(['a', 'c'])
+  })
+
+  test('handle PluginDependency objects array', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({ name: 'b' })
+    const pluginC = plugin({
+      name: 'c',
+      dependencies: [
+        { name: 'a' },
+        { name: 'b', optional: false },
+        { name: 'missing', optional: true }
+      ]
+    })
+
+    const result = resolveDependencies([pluginC, pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('handle duplicate plugins in the list', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+
+    const result = resolveDependencies([pluginA, pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b'])
+  })
+
+  test('resolve dependencies with version field (for future use)', () => {
+    const pluginA = plugin({ name: 'a' })
+    const pluginB = plugin({
+      name: 'b',
+      dependencies: [{ name: 'a', version: '1.0.0' }]
+    })
+
+    const result = resolveDependencies([pluginB, pluginA])
+
+    expect(result.map(p => p.name)).toEqual(['a', 'b'])
+  })
+
+  test('handle empty plugin array', () => {
+    const result = resolveDependencies([])
+
+    expect(result).toEqual([])
+  })
+
+  test('resolve complex circular dependency correctly', () => {
+    const pluginA = plugin({ name: 'a', dependencies: ['c'] })
+    const pluginB = plugin({ name: 'b', dependencies: ['a'] })
+    const pluginC = plugin({ name: 'c', dependencies: ['b'] })
+
+    expect(() => resolveDependencies([pluginA, pluginB, pluginC])).toThrow(
+      'Circular dependency detected'
+    )
   })
 })

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -613,12 +613,14 @@ describe('resolveDependencies', () => {
   })
 
   test('handle duplicate plugins in the list', () => {
+    const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const pluginA = plugin({ name: 'a' })
     const pluginB = plugin({ name: 'b', dependencies: ['a'] })
 
     const result = resolveDependencies([pluginA, pluginB, pluginA])
 
     expect(result.map(p => p.name)).toEqual(['a', 'b'])
+    expect(mockWarn).toHaveBeenCalledWith('Duplicate plugin name detected: a')
   })
 
   test('resolve dependencies with version field (for future use)', () => {

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -625,18 +625,6 @@ describe('resolveDependencies', () => {
     expect(mockWarn).toHaveBeenCalledWith('Duplicate plugin name detected: `a`')
   })
 
-  test('resolve dependencies with version field (for future use)', () => {
-    const pluginA = plugin({ name: 'a' })
-    const pluginB = plugin({
-      name: 'b',
-      dependencies: [{ name: 'a', version: '1.0.0' }]
-    })
-
-    const result = resolveDependencies([pluginB, pluginA])
-
-    expect(result.map(p => p.name)).toEqual(['a', 'b'])
-  })
-
   test('handle empty plugin array', () => {
     const result = resolveDependencies([])
 

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -604,11 +604,7 @@ describe('resolveDependencies', () => {
     const pluginB = plugin({ name: 'b' })
     const pluginC = plugin({
       name: 'c',
-      dependencies: [
-        { name: 'a' },
-        { name: 'b', optional: false },
-        { name: 'missing', optional: true }
-      ]
+      dependencies: ['a', { name: 'b', optional: false }, { name: 'missing', optional: true }]
     })
 
     const result = resolveDependencies([pluginC, pluginB, pluginA])

--- a/packages/gunshi/src/plugin.test.ts
+++ b/packages/gunshi/src/plugin.test.ts
@@ -573,20 +573,22 @@ describe('resolveDependencies', () => {
   test('throw error for missing required dependency', () => {
     const pluginB = plugin({ name: 'b', dependencies: ['a'] })
 
-    expect(() => resolveDependencies([pluginB])).toThrow('Missing required dependency: a')
+    expect(() => resolveDependencies([pluginB])).toThrow('Missing required dependency: `a` on `b`')
   })
 
   test('throw error for circular dependency', () => {
     const pluginA = plugin({ name: 'a', dependencies: ['b'] })
     const pluginB = plugin({ name: 'b', dependencies: ['a'] })
 
-    expect(() => resolveDependencies([pluginA, pluginB])).toThrow('Circular dependency detected: a')
+    expect(() => resolveDependencies([pluginA, pluginB])).toThrow(
+      'Circular dependency detected: `a`'
+    )
   })
 
   test('throw error for self-dependency', () => {
     const pluginA = plugin({ name: 'a', dependencies: ['a'] })
 
-    expect(() => resolveDependencies([pluginA])).toThrow('Circular dependency detected: a')
+    expect(() => resolveDependencies([pluginA])).toThrow('Circular dependency detected: `a`')
   })
 
   test('handle plugins without names', () => {
@@ -620,7 +622,7 @@ describe('resolveDependencies', () => {
     const result = resolveDependencies([pluginA, pluginB, pluginA])
 
     expect(result.map(p => p.name)).toEqual(['a', 'b'])
-    expect(mockWarn).toHaveBeenCalledWith('Duplicate plugin name detected: a')
+    expect(mockWarn).toHaveBeenCalledWith('Duplicate plugin name detected: `a`')
   })
 
   test('resolve dependencies with version field (for future use)', () => {

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -32,6 +32,15 @@ import type {
 export type { GlobalsCommandContext } from './plugins/globals.ts'
 
 /**
+ * Plugin dependency definition
+ */
+export interface PluginDependency {
+  name: string
+  optional?: boolean
+  version?: string
+}
+
+/**
  * Gunshi plugin context.
  * @internal
  */
@@ -174,6 +183,7 @@ export interface PluginOptions<
   G extends GunshiParams = DefaultGunshiParams
 > {
   name: string
+  dependencies?: (PluginDependency | string)[]
 
   setup?: PluginFunction<G>
   extension?: PluginExtension<T, G>
@@ -187,6 +197,7 @@ export interface PluginOptions<
 export type Plugin<E extends GunshiParams['extensions'] = DefaultGunshiParams['extensions']> =
   PluginFunction & {
     name?: string
+    dependencies?: (PluginDependency | string)[]
     extension?: CommandContextExtension<E>
   }
 
@@ -198,6 +209,7 @@ export interface PluginWithExtension<
   E extends GunshiParams['extensions'] = DefaultGunshiParams['extensions']
 > extends Plugin<E> {
   name: string
+  dependencies?: (PluginDependency | string)[]
   extension: CommandContextExtension<E>
 }
 
@@ -209,6 +221,7 @@ export interface PluginWithoutExtension<
   E extends GunshiParams['extensions'] = DefaultGunshiParams['extensions']
 > extends Plugin<E> {
   name: string
+  dependencies?: (PluginDependency | string)[]
 }
 
 /**
@@ -220,6 +233,7 @@ export function plugin<
   F extends PluginExtension<any, DefaultGunshiParams> // eslint-disable-line @typescript-eslint/no-explicit-any
 >(options: {
   name: N
+  dependencies?: PluginDependency[] | string[]
   setup?: (
     ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]: ReturnType<F> } }>>
   ) => Awaitable<void>
@@ -228,6 +242,7 @@ export function plugin<
 
 export function plugin(options: {
   name: string
+  dependencies?: PluginDependency[] | string[]
   setup?: (ctx: PluginContext<DefaultGunshiParams>) => Awaitable<void>
 }): PluginWithoutExtension<DefaultGunshiParams['extensions']>
 
@@ -237,6 +252,7 @@ export function plugin<
 >(
   options: {
     name: N
+    dependencies?: PluginDependency[] | string[]
     setup?: (
       ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]?: E } }>>
     ) => Awaitable<void>
@@ -244,7 +260,7 @@ export function plugin<
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
-  const { name, setup, extension } = options
+  const { name, setup, extension, dependencies } = options
 
   // create a wrapper function with properties
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -262,6 +278,14 @@ export function plugin<
       enumerable: true,
       configurable: true
     },
+    ...(dependencies && {
+      dependencies: {
+        value: dependencies,
+        writable: false,
+        enumerable: true,
+        configurable: true
+      }
+    }),
     ...(extension && {
       extension: {
         value: {
@@ -274,4 +298,66 @@ export function plugin<
       }
     })
   })
+}
+
+/**
+ * Resolve plugin dependencies using topological sort
+ * @param plugins - Array of plugins to resolve
+ * @returns Array of plugins sorted by dependencies
+ * @throws Error if circular dependency is detected or required dependency is missing
+ */
+export function resolveDependencies<E extends GunshiParams['extensions']>(
+  plugins: Plugin<E>[]
+): Plugin<E>[] {
+  const sorted: Plugin<E>[] = []
+  const visited = new Set<string>()
+  const visiting = new Set<string>()
+  const pluginMap = new Map<string, Plugin<E>>()
+
+  // build a map for quick lookup
+  for (const plugin of plugins) {
+    if (plugin.name) {
+      pluginMap.set(plugin.name, plugin)
+    }
+  }
+
+  function visit(plugin: Plugin<E>) {
+    if (!plugin.name) {
+      return
+    }
+    if (visited.has(plugin.name)) {
+      return
+    }
+    if (visiting.has(plugin.name)) {
+      throw new Error(`Circular dependency detected: ${plugin.name}`)
+    }
+
+    visiting.add(plugin.name)
+
+    // process dependencies first
+    const deps = plugin.dependencies || []
+    for (const dep of deps) {
+      const depName = typeof dep === 'string' ? dep : dep.name
+      const isOptional = typeof dep === 'string' ? false : dep.optional || false
+
+      const depPlugin = pluginMap.get(depName)
+      if (!depPlugin && !isOptional) {
+        throw new Error(`Missing required dependency: ${depName}`)
+      }
+      if (depPlugin) {
+        visit(depPlugin)
+      }
+    }
+
+    visiting.delete(plugin.name)
+    visited.add(plugin.name)
+    sorted.push(plugin)
+  }
+
+  // visit all plugins
+  for (const plugin of plugins) {
+    visit(plugin)
+  }
+
+  return sorted
 }

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -317,6 +317,9 @@ export function resolveDependencies<E extends GunshiParams['extensions']>(
   // build a map for quick lookup
   for (const plugin of plugins) {
     if (plugin.name) {
+      if (pluginMap.has(plugin.name)) {
+        console.warn(`Duplicate plugin name detected: ${plugin.name}`)
+      }
       pluginMap.set(plugin.name, plugin)
     }
   }

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -233,7 +233,7 @@ export function plugin<
   F extends PluginExtension<any, DefaultGunshiParams> // eslint-disable-line @typescript-eslint/no-explicit-any
 >(options: {
   name: N
-  dependencies?: PluginDependency[] | string[]
+  dependencies?: (PluginDependency | string)[]
   setup?: (
     ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]: ReturnType<F> } }>>
   ) => Awaitable<void>
@@ -242,7 +242,7 @@ export function plugin<
 
 export function plugin(options: {
   name: string
-  dependencies?: PluginDependency[] | string[]
+  dependencies?: (PluginDependency | string)[]
   setup?: (ctx: PluginContext<DefaultGunshiParams>) => Awaitable<void>
 }): PluginWithoutExtension<DefaultGunshiParams['extensions']>
 
@@ -252,7 +252,7 @@ export function plugin<
 >(
   options: {
     name: N
-    dependencies?: PluginDependency[] | string[]
+    dependencies?: (PluginDependency | string)[]
     setup?: (
       ctx: PluginContext<GunshiParams<{ args: Args; extensions: { [K in N]?: E } }>>
     ) => Awaitable<void>

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -35,9 +35,15 @@ export type { GlobalsCommandContext } from './plugins/globals.ts'
  * Plugin dependency definition
  */
 export interface PluginDependency {
+  /**
+   * Dependency plugin name
+   */
   name: string
+  /**
+   * Optional dependency flag.
+   * If true, the plugin will not throw an error if the dependency is not found.
+   */
   optional?: boolean
-  version?: string
 }
 
 /**
@@ -182,10 +188,21 @@ export interface PluginOptions<
   T extends Record<string, unknown> = Record<never, never>,
   G extends GunshiParams = DefaultGunshiParams
 > {
+  /**
+   * Plugin name
+   */
   name: string
+  /**
+   * Plugin dependencies
+   */
   dependencies?: (PluginDependency | string)[]
-
+  /**
+   * Plugin setup function
+   */
   setup?: PluginFunction<G>
+  /**
+   * Plugin extension
+   */
   extension?: PluginExtension<T, G>
 }
 

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -318,7 +318,7 @@ export function resolveDependencies<E extends GunshiParams['extensions']>(
   for (const plugin of plugins) {
     if (plugin.name) {
       if (pluginMap.has(plugin.name)) {
-        console.warn(`Duplicate plugin name detected: ${plugin.name}`)
+        console.warn(`Duplicate plugin name detected: \`${plugin.name}\``)
       }
       pluginMap.set(plugin.name, plugin)
     }
@@ -332,7 +332,7 @@ export function resolveDependencies<E extends GunshiParams['extensions']>(
       return
     }
     if (visiting.has(plugin.name)) {
-      throw new Error(`Circular dependency detected: ${plugin.name}`)
+      throw new Error(`Circular dependency detected: \`${plugin.name}\``)
     }
 
     visiting.add(plugin.name)
@@ -345,7 +345,7 @@ export function resolveDependencies<E extends GunshiParams['extensions']>(
 
       const depPlugin = pluginMap.get(depName)
       if (!depPlugin && !isOptional) {
-        throw new Error(`Missing required dependency: ${depName}`)
+        throw new Error(`Missing required dependency: \`${depName}\` on \`${plugin.name}\``)
       }
       if (depPlugin) {
         visit(depPlugin)

--- a/packages/gunshi/src/plugins/renderer.ts
+++ b/packages/gunshi/src/plugins/renderer.ts
@@ -14,6 +14,7 @@ import { renderValidationErrors } from '../renderer/validation.ts'
 export default function renderer() {
   return plugin({
     name: 'default-renderer',
+    dependencies: ['loader'],
     setup: ctx => {
       ctx.decorateHeaderRenderer(async (_baseRenderer, cmdCtx) => await renderHeader(cmdCtx))
       ctx.decorateUsageRenderer(async (_baseRenderer, cmdCtx) => await renderUsage(cmdCtx))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for plugin dependencies, allowing plugins to declare required or optional dependencies on other plugins.
  - Added a function to automatically resolve and order plugins based on their declared dependencies.
  - The default renderer plugin now explicitly declares a dependency on the loader plugin.

- **Bug Fixes**
  - Improved error handling for missing or circular plugin dependencies.

- **Tests**
  - Added comprehensive tests to verify correct dependency resolution and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->