### PR TITLE
feat: add `addCommand` as plugin API

### DIFF
--- a/packages/gunshi/src/plugin/context.test.ts
+++ b/packages/gunshi/src/plugin/context.test.ts
@@ -120,3 +120,156 @@ test('PluginContext#decorateCommand', async () => {
 
   expect(result).toBe('[USAGE] [TEST]')
 })
+
+describe('PluginContext#addCommand', () => {
+  test('basic', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const command = {
+      name: 'test',
+      description: 'Test command',
+      run: () => {
+        console.log('test')
+      }
+    }
+
+    ctx.addCommand('test', command)
+
+    expect(ctx.subCommands.size).toBe(1)
+    expect(ctx.subCommands.get('test')).toEqual(command)
+    expect(ctx.hasCommand('test')).toBe(true)
+  })
+
+  test('with initial sub commands', () => {
+    const decorators = createDecorators()
+    const initialCommand = {
+      name: 'initial',
+      description: 'Initial command',
+      run: () => {
+        console.log('initial')
+      }
+    }
+    const initialSubCommands = new Map([['initial', initialCommand]])
+
+    const ctx = createPluginContext(decorators, initialSubCommands)
+
+    expect(ctx.subCommands.size).toBe(1)
+    expect(ctx.subCommands.get('initial')).toEqual(initialCommand)
+
+    const newCommand = {
+      name: 'new',
+      description: 'New command',
+      run: () => {
+        console.log('new')
+      }
+    }
+
+    ctx.addCommand('new', newCommand)
+
+    expect(ctx.subCommands.size).toBe(2)
+    expect(ctx.subCommands.get('new')).toEqual(newCommand)
+    expect(ctx.hasCommand('new')).toBe(true)
+  })
+
+  test('lazy command', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const lazyCommand = Object.assign(
+      () => ({
+        name: 'lazy',
+        description: 'Lazy command',
+        run: () => {
+          console.log('lazy')
+        }
+      }),
+      {
+        commandName: 'lazy',
+        description: 'Lazy command'
+      }
+    )
+
+    ctx.addCommand('lazy', lazyCommand)
+
+    expect(ctx.subCommands.size).toBe(1)
+    expect(ctx.subCommands.get('lazy')).toEqual(lazyCommand)
+    expect(ctx.hasCommand('lazy')).toBe(true)
+  })
+
+  test('name empty', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const command = {
+      name: 'test',
+      description: 'Test command',
+      run: () => {
+        console.log('test')
+      }
+    }
+
+    expect(() => ctx.addCommand('', command)).toThrow('Command name must be a non-empty string')
+  })
+
+  test('duplicate name', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const command = {
+      name: 'test',
+      description: 'Test command',
+      run: () => {
+        console.log('test')
+      }
+    }
+
+    ctx.addCommand('test', command)
+
+    expect(() => ctx.addCommand('test', command)).toThrow(`Command 'test' is already registered`)
+  })
+})
+
+describe('PluginContext#hasCommand', () => {
+  test('returns true for existing command', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const command = {
+      name: 'test',
+      description: 'Test command',
+      run: () => {
+        console.log('test')
+      }
+    }
+
+    ctx.addCommand('test', command)
+
+    expect(ctx.hasCommand('test')).toBe(true)
+  })
+
+  test('returns false for non-existing command', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+
+    expect(ctx.hasCommand('nonexistent')).toBe(false)
+  })
+})
+
+describe('PluginContext#subCommands', () => {
+  test('returns readonly map', () => {
+    const decorators = createDecorators()
+    const ctx = createPluginContext(decorators)
+    const command = {
+      name: 'test',
+      description: 'Test command',
+      run: () => {
+        console.log('test')
+      }
+    }
+
+    ctx.addCommand('test', command)
+
+    const subCommands = ctx.subCommands
+    expect(subCommands.size).toBe(1)
+    expect(subCommands.get('test')).toEqual(command)
+
+    // verify that it's a new Map instance (readonly)
+    expect(subCommands).not.toBe(ctx.subCommands)
+  })
+})

--- a/packages/gunshi/src/plugin/context.ts
+++ b/packages/gunshi/src/plugin/context.ts
@@ -7,12 +7,14 @@ import type { ArgSchema } from 'args-tokens'
 import type { Decorators } from '../decorators.ts'
 import type {
   Awaitable,
+  Command,
   CommandContext,
   CommandDecorator,
   DefaultGunshiParams,
   ExtractArgs,
   ExtractExtensions,
   GunshiParamsConstraint,
+  LazyCommand,
   RendererDecorator,
   ValidationErrorsDecorator
 } from '../types.ts'
@@ -38,11 +40,34 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
   readonly globalOptions: Map<string, ArgSchema>
 
   /**
+   * Get the registered sub commands
+   * @returns A map of sub commands.
+   */
+  readonly subCommands: ReadonlyMap<string, Command<G> | LazyCommand<G>>
+
+  /**
    * Add a global option.
    * @param name An option name
    * @param schema An {@link ArgSchema} for the option
    */
   addGlobalOption(name: string, schema: ArgSchema): void
+
+  /**
+   * Add a sub command.
+   * @param name Command name
+   * @param command Command definition
+   */
+  addCommand<C extends GunshiParamsConstraint>(
+    name: string,
+    command: Command<C> | LazyCommand<C>
+  ): void
+
+  /**
+   * Check if a command exists.
+   * @param name Command name
+   * @returns True if the command exists, false otherwise
+   */
+  hasCommand(name: string): boolean
 
   /**
    * Decorate the header renderer.
@@ -98,16 +123,20 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
 /**
  * Factory function for creating a plugin context.
  * @param decorators - A {@link Decorators} instance.
+ * @param initialSubCommands - Initial sub commands map.
  * @returns A new {@link PluginContext} instance.
  */
 export function createPluginContext<G extends GunshiParamsConstraint = DefaultGunshiParams>(
-  decorators: Decorators<G>
+  decorators: Decorators<G>,
+  initialSubCommands?: Map<string, Command<G> | LazyCommand<G>>
 ): PluginContext<G> {
   /**
    * private states
    */
 
   const globalOptions = new Map<string, ArgSchema>()
+
+  const subCommands = new Map<string, Command<G> | LazyCommand<G>>(initialSubCommands || [])
 
   /**
    * public interfaces
@@ -126,6 +155,27 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
         throw new Error(`Global option '${name}' is already registered`)
       }
       globalOptions.set(name, schema)
+    },
+
+    get subCommands(): ReadonlyMap<string, Command<G> | LazyCommand<G>> {
+      return new Map(subCommands)
+    },
+
+    addCommand<C extends GunshiParamsConstraint>(
+      name: string,
+      command: Command<C> | LazyCommand<C>
+    ): void {
+      if (!name) {
+        throw new Error('Command name must be a non-empty string')
+      }
+      if (subCommands.has(name)) {
+        throw new Error(`Command '${name}' is already registered`)
+      }
+      subCommands.set(name, command as Command<G> | LazyCommand<G>)
+    },
+
+    hasCommand(name: string): boolean {
+      return subCommands.has(name)
     },
 
     decorateHeaderRenderer<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(

--- a/packages/gunshi/src/plugin/context.ts
+++ b/packages/gunshi/src/plugin/context.ts
@@ -57,10 +57,7 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
    * @param name Command name
    * @param command Command definition
    */
-  addCommand<C extends GunshiParamsConstraint>(
-    name: string,
-    command: Command<C> | LazyCommand<C>
-  ): void
+  addCommand(name: string, command: Command<G> | LazyCommand<G>): void
 
   /**
    * Check if a command exists.
@@ -161,17 +158,14 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
       return new Map(subCommands)
     },
 
-    addCommand<C extends GunshiParamsConstraint>(
-      name: string,
-      command: Command<C> | LazyCommand<C>
-    ): void {
+    addCommand(name: string, command: Command<G> | LazyCommand<G>): void {
       if (!name) {
         throw new Error('Command name must be a non-empty string')
       }
       if (subCommands.has(name)) {
         throw new Error(`Command '${name}' is already registered`)
       }
-      subCommands.set(name, command as Command<G> | LazyCommand<G>)
+      subCommands.set(name, command)
     },
 
     hasCommand(name: string): boolean {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to manage subcommands within the CLI plugin context, including viewing, adding, and checking for subcommands.
  * Enhanced CLI initialization to consolidate and normalize subcommands before plugin application.

* **Bug Fixes**
  * Improved validation to prevent duplicate or empty subcommand names when registering new commands.

* **Tests**
  * Introduced comprehensive tests to ensure correct command registration, existence checks, error handling, and immutability of the subcommands map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->