### PR TITLE
feat: add `internal` property for `Command` and `LazyCommand`

### DIFF
--- a/packages/gunshi/src/definition.test.ts
+++ b/packages/gunshi/src/definition.test.ts
@@ -187,7 +187,8 @@ describe('lazy with type parameters', () => {
       description: 'Test lazy command',
       args: { opt: { type: 'string' as const } },
       examples: 'lazy-test --opt value',
-      toKebab: true
+      toKebab: true,
+      internal: true
     })
 
     expect(lazyCmd.commandName).toBe('lazy-test')
@@ -195,6 +196,7 @@ describe('lazy with type parameters', () => {
     expect(lazyCmd.args).toEqual({ opt: { type: 'string' } })
     expect(lazyCmd.examples).toEqual('lazy-test --opt value')
     expect(lazyCmd.toKebab).toBe(true)
+    expect(lazyCmd.internal).toBe(true)
   })
 
   test('handles type parameters from loaded command', () => {

--- a/packages/gunshi/src/definition.ts
+++ b/packages/gunshi/src/definition.ts
@@ -168,6 +168,7 @@ export function lazy<G extends GunshiParamsConstraint = DefaultGunshiParams>(
     lazyCommand.description = definition.description
     lazyCommand.args = definition.args
     lazyCommand.examples = definition.examples
+    lazyCommand.internal = definition.internal
     // @ts-ignore - resource property is now provided by plugin-i18n
     if ('resource' in definition) {
       // @ts-ignore

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -407,6 +407,13 @@ export interface Command<G extends GunshiParamsConstraint = DefaultGunshiParams>
    * If you will set to `true`, All {@link Command.args} names will be converted to kebab-case.
    */
   toKebab?: boolean
+  /**
+   * Whether this is an internal command.
+   * Internal commands are not shown in help usage.
+   * @default false
+   * @since v0.27.0
+   */
+  internal?: boolean
 }
 
 /**

--- a/packages/gunshi/src/utils.ts
+++ b/packages/gunshi/src/utils.ts
@@ -30,7 +30,8 @@ export async function resolveLazyCommand<G extends GunshiParamsConstraint = Defa
       name: cmd.commandName,
       description: cmd.description,
       args: cmd.args,
-      examples: cmd.examples
+      examples: cmd.examples,
+      internal: cmd.internal
     }
     if ('resource' in cmd && cmd.resource) {
       baseCommand.resource = cmd.resource
@@ -50,6 +51,7 @@ export async function resolveLazyCommand<G extends GunshiParamsConstraint = Defa
         command.description = loaded.description
         command.args = loaded.args
         command.examples = loaded.examples
+        command.internal = loaded.internal
         if ('resource' in loaded && loaded.resource) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ;(command as any).resource = loaded.resource

--- a/packages/plugin-renderer/src/index.ts
+++ b/packages/plugin-renderer/src/index.ts
@@ -103,11 +103,12 @@ export default function renderer(): PluginWithExtension<UsageRendererCommandCont
         }
 
         const subCommands = [...(ctx.env.subCommands || [])] as [string, Command<G>][]
-        cachedCommands = (await Promise.all(
+        const allCommands = await Promise.all(
           subCommands.map(async ([name, cmd]) => await resolveLazyCommand(cmd, name))
-        )) as unknown as Command<DefaultGunshiParams>[]
+        )
 
-        return cachedCommands as unknown as Command<G>[]
+        // filter out internal commands
+        return (cachedCommands = allCommands.filter(cmd => !cmd.internal).filter(Boolean))
       }
 
       async function text<


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking commands as internal, allowing them to be hidden from help and usage outputs.

* **Bug Fixes**
  * Internal commands are now correctly filtered out from command listings and usage displays.

* **Tests**
  * Added tests to verify that internal commands are excluded from usage output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->