### PR TITLE
fix(gunshi): fix type error plugin onExtension, when extension is not define

### DIFF
--- a/packages/gunshi/src/plugin/core.test.ts
+++ b/packages/gunshi/src/plugin/core.test.ts
@@ -176,7 +176,7 @@ describe('plugin function', () => {
 
     expect(simplePlugin.id).toBe('simple-plugin')
     expect(simplePlugin.name).toBe('simple-plugin')
-    expect(simplePlugin.extension).toBeUndefined()
+    expect(simplePlugin.extension).toBeDefined()
 
     // check that setup function is callable
     const decorators = createDecorators()
@@ -247,7 +247,7 @@ describe('plugin function', () => {
         })
       }
     })
-    expect(testPlugin.extension).toBeUndefined()
+    expect(testPlugin.extension).toBeDefined()
   })
 })
 

--- a/packages/gunshi/src/plugin/core.ts
+++ b/packages/gunshi/src/plugin/core.ts
@@ -15,6 +15,10 @@ import type {
 } from '../types.ts'
 import type { PluginContext } from './context.ts'
 
+const NOOP_EXTENSION = () => {
+  return Object.create(null)
+}
+
 /**
  * Plugin dependency definition
  * @since v0.27.0
@@ -163,6 +167,7 @@ export function plugin(options: {
   name?: string
   dependencies?: (PluginDependency | string)[]
   setup?: (ctx: Readonly<PluginContext<DefaultGunshiParams>>) => Awaitable<void>
+  onExtension?: OnPluginExtension<DefaultGunshiParams>
 }): PluginWithoutExtension<DefaultGunshiParams['extensions']>
 
 /**
@@ -184,7 +189,8 @@ export function plugin<
   extension?: PluginExtension<E, DefaultGunshiParams>
   onExtension?: OnPluginExtension<{ args: Args; extensions: { [K in I]?: E } }>
 }): PluginWithExtension<E> | PluginWithoutExtension<DefaultGunshiParams['extensions']> {
-  const { id, name, setup, extension, onExtension, dependencies } = options
+  const { id, name, setup, onExtension, dependencies } = options
+  const extension = options.extension || (NOOP_EXTENSION as PluginExtension<E, DefaultGunshiParams>)
 
   // create a wrapper function with properties
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin-completion/src/index.ts
+++ b/packages/plugin-completion/src/index.ts
@@ -10,8 +10,14 @@ import { pluginId } from './types.ts'
 import { quoteExec } from './utils.ts'
 
 import type { Handler } from '@bombsh/tab'
-import type { Args, Command, LazyCommand, PluginContext, PluginWithExtension } from '@gunshi/plugin'
-import type { CompletionCommandContext, CompletionConfig, CompletionOptions } from './types.ts'
+import type {
+  Args,
+  Command,
+  LazyCommand,
+  PluginContext,
+  PluginWithoutExtension
+} from '@gunshi/plugin'
+import type { CompletionConfig, CompletionOptions } from './types.ts'
 
 export * from './types.ts'
 
@@ -27,9 +33,7 @@ const NOOP_HANDLER: Handler = () => {
 /**
  * completion plugin for gunshi
  */
-export default function completion(
-  options: CompletionOptions = {}
-): PluginWithExtension<CompletionCommandContext> {
+export default function completion(options: CompletionOptions = {}): PluginWithoutExtension {
   const config = options.config || {}
   const completion = new Completion()
 
@@ -76,18 +80,11 @@ export default function completion(
       ctx.decorateHeaderRenderer(async (_baseRenderer, _cmdCtx) => '')
     },
 
-    // TODO(kazupon): type inference with plugin function type parameter
-    extension: (_ctx, _cmd): CompletionCommandContext => {
-      return {} as CompletionCommandContext
-    },
-
     /**
      * setup bombshell completion with `onExtension` hook
      */
 
     onExtension: async (ctx, _cmd) => {
-      // TODO(kazupon): type inference with plugin function type parameter, more improvements!
-
       // NOTE(kazupon): we should use plugin-i18n for completion localization, but it is not ready yet.
       // const extensions = ctx.extensions as unknown as { [i18nPluginId]: I18nCommandContext }
       // const i18n = extensions[i18nPluginId]


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the plugin system always provides a defined extension property, improving consistency across plugins.
* **Refactor**
  * Simplified plugin type usage in the completion plugin by removing unnecessary extension-related types and properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->