### PR TITLE
Update README.md - add varlock to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ About more details and usage, see [documentations](https://gunshi.dev)
 - [sourcemap-publisher](https://github.com/es-tooling/sourcemap-publisher): A tool to publish sourcemaps externally and rewrite sourcemap URLs at pre-publish time
 - [curxy](https://github.com/ryoppippi/curxy): An proxy worker for using ollama in cursor
 - [SiteMCP](https://github.com/ryoppippi/sitemcp): Fetch an entire site and use it as an MCP Server
-- [ccusage](https://github.com/ryoppippi/ccusage): A CLI tool for analyzing Claude Code usage from local JSONL files.
+- [ccusage](https://github.com/ryoppippi/ccusage): A CLI tool for analyzing Claude Code usage from local JSONL files
+- [varlock](https://github.com/dmno-dev/varlock): Enhanced .env file loader, using @decorator style comments to add validation, type-safety, and more
 
 ## 🙌 Contributing guidelines
 


### PR DESCRIPTION
### Description

Adds https://varlock.dev to showcase list :)

Thanks for your work on gunshi! Was about to build something similar and it saved me a ton of time.