### PR TITLE
fix: improve sub commands usage rendering

### DIFF
--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -1,12 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`auto generate usage > inline function > USAGE:
-  COMMAND <OPTIONS>
-
-OPTIONS:
-  -h, --help             Display this help message
-  -v, --version          Display this version
- 1`] = `
+exports[`auto generate usage > inline function > console 1`] = `
 "USAGE:
   COMMAND <OPTIONS>
 
@@ -16,7 +10,7 @@ OPTIONS:
 "
 `;
 
-exports[`auto generate usage > inline function 1`] = `
+exports[`auto generate usage > inline function > rendered 1`] = `
 "USAGE:
   COMMAND <OPTIONS>
 
@@ -26,83 +20,30 @@ OPTIONS:
 "
 `;
 
-exports[`auto generate usage > loosely entry command > USAGE:
-  COMMAND <OPTIONS>
-
-OPTIONS:
-  -h, --help               Display this help message
-  -v, --version            Display this version
-  -f, --foo <foo>          
- 1`] = `
+exports[`auto generate usage > loosely entry command > console 1`] = `
 "USAGE:
   COMMAND <OPTIONS>
 
 OPTIONS:
   -h, --help               Display this help message
   -v, --version            Display this version
-  -f, --foo <foo>          
+  -f, --foo <foo>
 "
 `;
 
-exports[`auto generate usage > loosely entry command 1`] = `
+exports[`auto generate usage > loosely entry command > rendered 1`] = `
 "USAGE:
   COMMAND <OPTIONS>
 
 OPTIONS:
   -h, --help               Display this help message
   -v, --version            Display this version
-  -f, --foo <foo>          
+  -f, --foo <foo>
 "
 `;
 
 exports[`auto generate usage > loosely sub commands > command2 1`] = `
-"USAGE:
-  my-cli command2 <OPTIONS>
-
-OPTIONS:
-  -h, --help               Display this help message
-  -v, --version            Display this version
-  -b, --bar [bar]           (default: 42)
-"
-`;
-
-exports[`auto generate usage > loosely sub commands > main 1`] = `
-"USAGE:
-  my-cli [command1] <OPTIONS>
-  my-cli <COMMANDS>
-
-COMMANDS:
-  command2            
-  command1            
-
-For more info, run any command with the \`--help\` flag:
-  my-cli command2 --help
-  my-cli command1 --help
-
-OPTIONS:
-  -h, --help               Display this help message
-  -v, --version            Display this version
-  -f, --foo <foo>          
-"
-`;
-
-exports[`auto generate usage > loosely sub commands 1`] = `
-"USAGE:
-  my-cli [command1] <OPTIONS>
-  my-cli <COMMANDS>
-
-COMMANDS:
-  command2            
-  command1            
-
-For more info, run any command with the \`--help\` flag:
-  my-cli command2 --help
-  my-cli command1 --help
-
-OPTIONS:
-  -h, --help               Display this help message
-  -v, --version            Display this version
-  -f, --foo <foo>          
+"This is command2
 
 USAGE:
   my-cli command2 <OPTIONS>
@@ -114,7 +55,57 @@ OPTIONS:
 "
 `;
 
-exports[`auto generate usage > strictly entry command > Modern CLI tool (gunshi v0.0.0)
+exports[`auto generate usage > loosely sub commands > console output 1`] = `
+"USAGE:
+  my-cli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS>                     This is entry command
+  command2 <OPTIONS>            This is command2
+
+For more info, run any command with the \`--help\` flag:
+  my-cli --help
+  my-cli command2 --help
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
+
+This is command2
+
+USAGE:
+  my-cli command2 <OPTIONS>
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -b, --bar [bar]           (default: 42)
+"
+`;
+
+exports[`auto generate usage > loosely sub commands > entry 1`] = `
+"USAGE:
+  my-cli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS>                     This is entry command
+  command2 <OPTIONS>            This is command2
+
+For more info, run any command with the \`--help\` flag:
+  my-cli --help
+  my-cli command2 --help
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
+"
+`;
+
+exports[`auto generate usage > strictly entry command > console 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+
 USAGE:
   gunshi <OPTIONS>
 
@@ -128,9 +119,11 @@ EXAMPLES:
   $ gunshi --foo bar
   # Example 2
   $ gunshi -f bar
- 1`] = `
-"Modern CLI tool (gunshi v0.0.0)
+"
+`;
 
+exports[`auto generate usage > strictly entry command > rendered 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
 USAGE:
   gunshi <OPTIONS>
 
@@ -138,6 +131,26 @@ OPTIONS:
   -h, --help               [boolean] Display this help message
   -v, --version            [boolean] Display this version
   -f, --foo <foo>          [string]  The foo option
+
+EXAMPLES:
+  # Example 1
+  $ gunshi --foo bar
+  # Example 2
+  $ gunshi -f bar
+"
+`;
+
+exports[`auto generate usage > strictly sub commands > command1 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+This is command1 (entry)
+
+USAGE:
+  gunshi command1 <OPTIONS>
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
 
 EXAMPLES:
   # Example 1
@@ -149,6 +162,8 @@ EXAMPLES:
 
 exports[`auto generate usage > strictly sub commands > command2 1`] = `
 "Modern CLI tool (gunshi v0.0.0)
+This is command2
+
 USAGE:
   gunshi command2 <OPTIONS>
 
@@ -165,47 +180,19 @@ EXAMPLES:
 "
 `;
 
-exports[`auto generate usage > strictly sub commands > main 1`] = `
-"Modern CLI tool (gunshi v0.0.0)
-使い方:
-    gunshi [command1] <オプション>
-    gunshi <コマンド>
-
-コマンド:
-    command2                 
-    command1                 
-
-詳細は、コマンドと\`--help\`フラグを実行してください:
-    gunshi command2 --help
-    gunshi command1 --help
-
-オプション:
-    -h, --help                    Display this help message
-    -v, --version                 Display this version
-    -f, --foo <foo>               The foo option
-
-例:
-    # Example 1
-    $ gunshi --foo bar
-    # Example 2
-    $ gunshi -f bar
-"
-`;
-
-exports[`auto generate usage > strictly sub commands 1`] = `
+exports[`auto generate usage > strictly sub commands > console output 1`] = `
 "Modern CLI tool (gunshi v0.0.0)
 
 使い方:
-    gunshi [command1] <オプション>
-    gunshi <コマンド>
+    gunshi [コマンド] <オプション>
 
 コマンド:
-    command2                 
-    command1                 
+    [command1] <オプション>            This is command1 (entry)
+    command2 <オプション>              This is command2
 
 詳細は、コマンドと\`--help\`フラグを実行してください:
+    gunshi --help
     gunshi command2 --help
-    gunshi command1 --help
 
 オプション:
     -h, --help                    Display this help message
@@ -220,6 +207,26 @@ exports[`auto generate usage > strictly sub commands 1`] = `
 
 Modern CLI tool (gunshi v0.0.0)
 
+This is command1 (entry)
+
+USAGE:
+  gunshi command1 <OPTIONS>
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
+
+EXAMPLES:
+  # Example 1
+  $ gunshi --foo bar
+  # Example 2
+  $ gunshi -f bar
+
+Modern CLI tool (gunshi v0.0.0)
+
+This is command2
+
 USAGE:
   gunshi command2 <OPTIONS>
 
@@ -233,6 +240,32 @@ EXAMPLES:
   $ gunshi command2 --bar 42
   # Example 2
   $ gunshi command2 -b 42
+"
+`;
+
+exports[`auto generate usage > strictly sub commands > entry 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+使い方:
+    gunshi [コマンド] <オプション>
+
+コマンド:
+    [command1] <オプション>            This is command1 (entry)
+    command2 <オプション>              This is command2
+
+詳細は、コマンドと\`--help\`フラグを実行してください:
+    gunshi --help
+    gunshi command2 --help
+
+オプション:
+    -h, --help                    Display this help message
+    -v, --version                 Display this version
+    -f, --foo <foo>               The foo option
+
+例:
+    # Example 1
+    $ gunshi --foo bar
+    # Example 2
+    $ gunshi -f bar
 "
 `;
 
@@ -272,6 +305,105 @@ OPTIONS:
   -h, --help                               Display this help message
   -v, --version                            Display this version
   -d, --description <description>          This is a description of description option
+"
+`;
+
+exports[`github issues > #252 > console output 1`] = `
+"mycli description (mycli v1.2.3)
+
+USAGE:
+  mycli <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+
+mycli description (mycli v1.2.3)
+
+USAGE:
+  mycli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS> 
+  cmd1 <OPTIONS>
+
+For more info, run any command with the \`--help\` flag:
+  mycli --help
+  mycli cmd1 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+
+mycli description (mycli v1.2.3)
+
+USAGE:
+  mycli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS> 
+  cmd1 <OPTIONS>
+  cmd2 <OPTIONS>
+
+For more info, run any command with the \`--help\` flag:
+  mycli --help
+  mycli cmd1 --help
+  mycli cmd2 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`github issues > #252 > example1 1`] = `
+"mycli description (mycli v1.2.3)
+USAGE:
+  mycli <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`github issues > #252 > example2 1`] = `
+"mycli description (mycli v1.2.3)
+USAGE:
+  mycli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS> 
+  cmd1 <OPTIONS>
+
+For more info, run any command with the \`--help\` flag:
+  mycli --help
+  mycli cmd1 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`github issues > #252 > example3 1`] = `
+"mycli description (mycli v1.2.3)
+USAGE:
+  mycli [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS> 
+  cmd1 <OPTIONS>
+  cmd2 <OPTIONS>
+
+For more info, run any command with the \`--help\` flag:
+  mycli --help
+  mycli cmd1 --help
+  mycli cmd2 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
 "
 `;
 

--- a/packages/gunshi/src/index.ts
+++ b/packages/gunshi/src/index.ts
@@ -25,6 +25,7 @@
 export { DefaultTranslation } from '@gunshi/plugin-i18n' // TODO(kazupon): remove this import after the next major release
 export { parseArgs, resolveArgs } from 'args-tokens'
 export * from './cli.ts'
+export { ANONYMOUS_COMMAND_NAME } from './constants.ts'
 export { define, lazy } from './definition.ts'
 export { plugin } from './plugin/core.ts'
 

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -23,7 +23,7 @@
  * @license MIT
  */
 
-export { CLI_OPTIONS_DEFAULT } from './constants.ts'
+export { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT } from './constants.ts'
 export { createCommandContext } from './context.ts'
 export { plugin } from './plugin/core.ts'
 

--- a/packages/plugin-renderer/src/__snapshots__/usage.test.ts.snap
+++ b/packages/plugin-renderer/src/__snapshots__/usage.test.ts.snap
@@ -101,7 +101,7 @@ exports[`no arguments 1`] = `
 "A test command
 
 USAGE:
-  cmd1 test 
+  cmd1 test
 
 EXAMPLES:
   # Example 1
@@ -177,18 +177,17 @@ ARGUMENTS:
 
 exports[`sub commands 1`] = `
 "USAGE:
-  cmd1 [show] <OPTIONS> <positional1>
-  cmd1 <COMMANDS>
+  cmd1 [COMMANDS] <OPTIONS> <positional1>
 
 COMMANDS:
-  show              A show command  
-  command1          this is command1  
-  command2            
+  command1 <OPTIONS> <positional1>        this is command1
+  command2 <OPTIONS> <positional1>
+  show <OPTIONS> <positional1>            A show command
 
 For more info, run any command with the \`--help\` flag:
-  cmd1 show --help
   cmd1 command1 --help
   cmd1 command2 --help
+  cmd1 show --help
 
 ARGUMENTS:
   positional1           The positional argument 1

--- a/packages/plugin-renderer/src/index.ts
+++ b/packages/plugin-renderer/src/index.ts
@@ -99,7 +99,20 @@ export default function renderer(): PluginWithExtension<UsageRendererCommandCont
         )
 
         // filter out internal commands
-        return (cachedCommands = allCommands.filter(cmd => !cmd.internal).filter(Boolean))
+        cachedCommands = allCommands.filter(cmd => !cmd.internal).filter(Boolean)
+        cachedCommands.sort((a, b) => {
+          if (a.entry) {
+            return -1 // prioritize entry commands
+          }
+          if (a.name?.localeCompare(b.name || '') === 0) {
+            return 0 // keep the order of commands with the same name
+          }
+          if (a.name && b.name) {
+            return a.name.localeCompare(b.name) // sort by name
+          }
+          return 0 // fallback to no change
+        })
+        return cachedCommands
       }
 
       return {

--- a/packages/plugin-renderer/src/index.ts
+++ b/packages/plugin-renderer/src/index.ts
@@ -101,16 +101,28 @@ export default function renderer(): PluginWithExtension<UsageRendererCommandCont
         // filter out internal commands
         cachedCommands = allCommands.filter(cmd => !cmd.internal).filter(Boolean)
         cachedCommands.sort((a, b) => {
-          if (a.entry) {
-            return -1 // prioritize entry commands
+          // first, prioritize entry commands
+          if (a.entry && !b.entry) {
+            return -1
           }
-          if (a.name?.localeCompare(b.name || '') === 0) {
-            return 0 // keep the order of commands with the same name
+          if (!a.entry && b.entry) {
+            return 1
           }
+
+          // then sort by name
           if (a.name && b.name) {
-            return a.name.localeCompare(b.name) // sort by name
+            return a.name.localeCompare(b.name)
           }
-          return 0 // fallback to no change
+
+          // handle cases where one or both names are missing
+          if (a.name && !b.name) {
+            return -1
+          }
+          if (!a.name && b.name) {
+            return 1
+          }
+
+          return 0 // keep original order if both have no name
         })
         return cachedCommands
       }

--- a/packages/plugin-renderer/src/usage.test.ts
+++ b/packages/plugin-renderer/src/usage.test.ts
@@ -162,7 +162,7 @@ test('basic', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -196,7 +196,7 @@ test('no arguments', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -244,7 +244,7 @@ test('no required on optional arguments', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -286,7 +286,7 @@ test('positional arguments', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -338,7 +338,7 @@ test('mixed positionals and optionals', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -392,7 +392,7 @@ test('no examples', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -447,7 +447,7 @@ test('enable usageOptionType', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -537,7 +537,7 @@ test('kebab-case arguments with toKebab option', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -594,7 +594,7 @@ test('kebab-case arguments with Command.toKebab option', async () => {
     argv: [],
     tokens: [], // dummy, due to test
     omitted: false,
-    callMode: 'entry',
+    callMode: 'subCommand',
     command,
     extensions: {
       [i18nPlugin.id]: i18nPlugin.extension,
@@ -670,7 +670,7 @@ test('internal commands are filtered out', async () => {
     explicit: {},
     values: {},
     omitted: true,
-    callMode: 'entry',
+    callMode: 'subCommand',
     positionals: [],
     rest: [],
     argv: [],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

resolve #252 
resolve #68 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command sorting in the renderer plugin, prioritizing entry commands and providing more consistent ordering.
  * Enhanced CLI help rendering to better handle commands with varying numbers of subcommands.
  * Added new public export for anonymous command naming.

* **Refactor**
  * Refactored usage rendering logic for clearer formatting and improved alignment in help output.
  * Introduced helper functions for constructing usage and command symbols, increasing consistency in help displays.
  * Decoupled argument handling from command context for improved maintainability.

* **Tests**
  * Expanded test coverage for CLI usage generation, including new scenarios and improved snapshot clarity.
  * Adjusted test contexts to better reflect subcommand call modes for accurate usage rendering tests.

* **Chores**
  * Updated public exports to include additional constants for broader accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->