### PR TITLE
feat: add fallbackToEntry option for CLI command resolution

### DIFF
--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -160,14 +160,10 @@ describe('execute command', () => {
     await cli(['show'], show, options)
     await cli(['command1', '--foo', 'foo', 'position1'], show, options)
     await cli(['command2', '--bar=1', 'position2'], show, options)
-    await cli(['position3'], show, options)
 
-    expect(mockShow).toBeCalledTimes(3)
+    expect(mockShow).toBeCalledTimes(2)
     expect(mockShow).toHaveBeenCalledWith(
       expect.objectContaining({ callMode: 'entry', positionals: [''] })
-    )
-    expect(mockShow).toHaveBeenCalledWith(
-      expect.objectContaining({ callMode: 'entry', positionals: ['positional3'] })
     )
     expect(mockCommand1).toBeCalledTimes(1)
     expect(mockCommand1).toHaveBeenCalledWith(
@@ -185,6 +181,68 @@ describe('execute command', () => {
         callMode: 'subCommand'
       })
     )
+  })
+
+  test('fallback to entry command', async () => {
+    const mockShow = vi.fn()
+    const mockCommand1 = vi.fn()
+    const mockCommand2 = vi.fn()
+    const show = {
+      name: 'show',
+      run: mockShow
+    }
+    const subCommands = new Map()
+    subCommands.set('command1', {
+      name: 'command1',
+      args: {
+        foo: {
+          type: 'string',
+          short: 'f'
+        }
+      },
+      run: mockCommand1
+    })
+    subCommands.set('command2', {
+      name: 'command2',
+      args: {
+        bar: {
+          type: 'number',
+          short: 'b'
+        }
+      },
+      run: mockCommand2
+    })
+
+    await expect(
+      cli(['position1'], show, {
+        subCommands
+      })
+    ).rejects.toThrowError('Command not found: position1')
+    await expect(
+      cli(['position2'], show, {
+        subCommands,
+        fallbackToEntry: false
+      })
+    ).rejects.toThrowError('Command not found: position2')
+    await expect(
+      cli(['position3'], show, {
+        subCommands,
+        fallbackToEntry: true
+      })
+    ).resolves.toBeUndefined()
+    await expect(
+      cli(['command1'], show, {
+        subCommands,
+        fallbackToEntry: true
+      })
+    ).resolves.toBeUndefined()
+
+    expect(mockShow).toBeCalledTimes(1)
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({ callMode: 'entry', positionals: ['position3'] })
+    )
+    expect(mockCommand1).toBeCalledTimes(1)
+    expect(mockCommand2).toBeCalledTimes(0)
   })
 
   test('entry loose command + sub commands', async () => {

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -160,9 +160,15 @@ describe('execute command', () => {
     await cli(['show'], show, options)
     await cli(['command1', '--foo', 'foo', 'position1'], show, options)
     await cli(['command2', '--bar=1', 'position2'], show, options)
+    await cli(['position3'], show, options)
 
-    expect(mockShow).toBeCalledTimes(2)
-    expect(mockShow).toHaveBeenCalledWith(expect.objectContaining({ callMode: 'entry' }))
+    expect(mockShow).toBeCalledTimes(3)
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({ callMode: 'entry', positionals: [''] })
+    )
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({ callMode: 'entry', positionals: ['positional3'] })
+    )
     expect(mockCommand1).toBeCalledTimes(1)
     expect(mockCommand1).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -257,6 +257,9 @@ async function resolveCommand<G extends GunshiParamsConstraint>(
 
   const cmd = options.subCommands?.get(sub)
   if (cmd == null) {
+    if (options.fallbackToEntry) {
+      return doResolveCommand()
+    }
     return {
       commandName: sub,
       callMode: 'unexpected'

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -279,6 +279,10 @@ export interface CliOptions<G extends GunshiParamsConstraint = DefaultGunshiPara
     | ((ctx: Readonly<CommandContext<G>>, error: AggregateError) => Promise<string>)
     | null
   /**
+   * Whether to fallback to entry command when the sub-command is not found.
+   */
+  fallbackToEntry?: boolean
+  /**
    * User plugins.
    *
    * @since v0.27.0


### PR DESCRIPTION
## Summary
- Add `fallbackToEntry` option to `CliOptions` interface
- Implement fallback functionality when sub-command is not found
- Enable more flexible command handling for CLI applications

## Changes
- `types.ts`: Add `fallbackToEntry` option to `CliOptions` interface
- `cli/core.ts`: Implement fallback logic in sub-command resolution
- `cli.test.ts`: Add comprehensive test cases for fallback functionality

## Test plan
- [x] Existing tests continue to pass
- [x] With `fallbackToEntry: false`, unknown sub-commands throw errors
- [x] With `fallbackToEntry: true`, unknown sub-commands fall back to entry command
- [x] Valid sub-commands continue to work correctly
- [x] Positional arguments are properly passed to fallback entry command

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>