### PR TITLE
fix(plugin-i18n): change to `builtinResources` option

### DIFF
--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -555,7 +555,7 @@ describe('auto generate usage', () => {
       plugins: [
         i18n({
           locale: 'ja-JP',
-          resources: { 'ja-JP': jsJPResource }
+          builtinResources: { 'ja-JP': jsJPResource }
         })
       ]
     })

--- a/packages/plugin-i18n/README.md
+++ b/packages/plugin-i18n/README.md
@@ -79,7 +79,7 @@ await cli(process.argv.slice(2), greetCommand, {
 - Default: `'en-US'`
 - Description: The locale to use for translations. Can be a BCP 47 language tag string or an `Intl.Locale` object.
 
-### `resources`
+### `builtinResources`
 
 - Type: `Record<string, Record<BuiltinResourceKeys, string>>`
 - Default: `{}`
@@ -120,7 +120,7 @@ await cli(args, command, {
     globals(), // Adds --help and --version options
     i18n({
       locale: 'ja-JP',
-      resources: {
+      builtinResources: {
         'ja-JP': jsJPResource // Set from with providing gunshi built-in resources
       }
     })

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -69,7 +69,7 @@ describe('extension: translate', () => {
       const jaJPResource = await import('@gunshi/resources/ja-JP', { with: { type: 'json' } }).then(
         m => m.default || m
       )
-      const plugin = i18n({ locale: 'ja-JP', resources: { 'ja-JP': jaJPResource } })
+      const plugin = i18n({ locale: 'ja-JP', builtinResources: { 'ja-JP': jaJPResource } })
       const ctx = await createMockCommandContext()
       const extension = await plugin.extension.factory(ctx, {} as Command)
 

--- a/packages/plugin-i18n/src/index.ts
+++ b/packages/plugin-i18n/src/index.ts
@@ -83,8 +83,8 @@ export default function i18n(
   const locale = toLocale(options.locale)
   const localeStr = toLocaleString(locale)
 
-  const resources =
-    options.resources ||
+  const builtinResources =
+    options.builtinResources ||
     (Object.create(null) as Record<string, Record<BuiltinResourceKeys, string>>)
 
   // create translation adapter
@@ -150,7 +150,7 @@ export default function i18n(
       setResource(DEFAULT_LOCALE, DefaultResource as Record<BuiltinResourceKeys, string>)
 
       // install built-in locale resources
-      for (const [locale, resource] of Object.entries(resources)) {
+      for (const [locale, resource] of Object.entries(builtinResources)) {
         setResource(locale, resource)
       }
 

--- a/packages/plugin-i18n/src/types.ts
+++ b/packages/plugin-i18n/src/types.ts
@@ -90,7 +90,7 @@ export interface I18nPluginOptions {
   /**
    * Built-in localizable resources
    */
-  resources?: Record<string, Record<BuiltinResourceKeys, string>>
+  builtinResources?: Record<string, Record<BuiltinResourceKeys, string>>
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Make the strictly option names for `pluign-i18n` finer to reduce cognitive load.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the i18n plugin option from “resources” to “builtinResources” with the same structure and behavior. This is a public API change and may require updating existing configurations.
- Documentation
  - Updated README and examples to use “builtinResources” and clarified defaults.
- Tests
  - Updated tests to configure i18n using the new “builtinResources” option for built-in translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->