### PR TITLE
fix(gunshi): re-export `CommandContext.log` again

### DIFF
--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -400,7 +400,6 @@ export interface CommandContext<G extends GunshiParamsConstraint = DefaultGunshi
    *
    * @param message - an output message, @see {@link console.log}
    * @param optionalParams - an optional parameters, @see {@link console.log}
-   * @internal
    */
   log: (message?: any, ...optionalParams: any[]) => void // eslint-disable-line @typescript-eslint/no-explicit-any -- NOTE(kazupon): generic optional parameters
   /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified visibility of the logging utility in the command context by updating annotations.
  * Ensures it appears in public API documentation and IDE autocomplete, reducing confusion for integrators.
  * No changes to behavior, runtime, or public/type signatures; purely a documentation update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->