### PR TITLE
fix(lazy-async): resolve command before executing

### DIFF
--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -407,6 +407,38 @@ OPTIONS:
 "
 `;
 
+exports[`lazy command > command loading > config-command 1`] = `
+"lazy-command-loading (lazy-command-loading v1.0.0)
+Loaded configured command
+
+USAGE:
+  lazy-command-loading config <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`lazy command > command loading > default-command 1`] = `
+"lazy-command-loading (lazy-command-loading v1.0.0)
+USAGE:
+  lazy-command-loading [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS>                     CLI with dynamic commands
+  config <OPTIONS>              Load command configuration
+
+For more info, run any command with the \`--help\` flag:
+  lazy-command-loading --help
+  lazy-command-loading config --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
 exports[`usageSilent 1`] = `
 "Modern CLI tool (gunshi v0.0.0)
 USAGE:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined command execution to resolve lazy-loaded commands earlier, ensuring consistent behavior and decorator application. No changes to CLI usage.
- Tests
  - Reorganized and expanded test coverage for lazy-loaded commands, including a new scenario for configuration-driven command loading.
  - Added usage and snapshot validations across multiple command cases to improve confidence and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->