### PR TITLE
fix(gunshi): resolve command name via function name for entry

### DIFF
--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -1,25 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`auto generate usage > inline function > console 1`] = `
-"USAGE:
-  COMMAND <OPTIONS>
-
-OPTIONS:
-  -h, --help             Display this help message
-  -v, --version          Display this version
-"
-`;
-
-exports[`auto generate usage > inline function > rendered 1`] = `
-"USAGE:
-  COMMAND <OPTIONS>
-
-OPTIONS:
-  -h, --help             Display this help message
-  -v, --version          Display this version
-"
-`;
-
 exports[`auto generate usage > loosely entry command > console 1`] = `
 "USAGE:
   COMMAND <OPTIONS>
@@ -39,6 +19,26 @@ OPTIONS:
   -h, --help               Display this help message
   -v, --version            Display this version
   -f, --foo <foo>
+"
+`;
+
+exports[`auto generate usage > loosely inline command > console 1`] = `
+"USAGE:
+  COMMAND <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`auto generate usage > loosely inline command > rendered 1`] = `
+"USAGE:
+  COMMAND <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
 "
 `;
 
@@ -100,6 +100,70 @@ OPTIONS:
   -h, --help               Display this help message
   -v, --version            Display this version
   -f, --foo <foo>          The foo option
+"
+`;
+
+exports[`auto generate usage > named entry command + sub commands > command1 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+This is command1 (entry)
+
+USAGE:
+  gunshi command1 <OPTIONS>
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
+"
+`;
+
+exports[`auto generate usage > named entry command + sub commands > entry 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+USAGE:
+  gunshi [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  [entry] <OPTIONS>
+  command1 <OPTIONS>         This is command1 (entry)
+
+For more info, run any command with the \`--help\` flag:
+  gunshi --help
+  gunshi command1 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`auto generate usage > named entry command + sub commands > explicit entry 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+USAGE:
+  gunshi entry <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`auto generate usage > named entry command > console 1`] = `
+"USAGE:
+  COMMAND <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
+exports[`auto generate usage > named entry command > rendered 1`] = `
+"USAGE:
+  COMMAND <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
 "
 `;
 

--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -1,5 +1,38 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`auto generate usage > inline entry command + sub commands > command1 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+This is command1 (entry)
+
+USAGE:
+  gunshi command1 <OPTIONS>
+
+OPTIONS:
+  -h, --help               Display this help message
+  -v, --version            Display this version
+  -f, --foo <foo>          The foo option
+"
+`;
+
+exports[`auto generate usage > inline entry command + sub commands > entry 1`] = `
+"Modern CLI tool (gunshi v0.0.0)
+USAGE:
+  gunshi [COMMANDS] <OPTIONS>
+
+COMMANDS:
+  <OPTIONS> 
+  command1 <OPTIONS>            This is command1 (entry)
+
+For more info, run any command with the \`--help\` flag:
+  gunshi --help
+  gunshi command1 --help
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+"
+`;
+
 exports[`auto generate usage > loosely entry command > console 1`] = `
 "USAGE:
   COMMAND <OPTIONS>

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -674,6 +674,41 @@ describe('auto generate usage', () => {
     expect(renderedCommand1).toMatchSnapshot('command1')
     expect(log()).toBeTruthy()
   })
+
+  test('inline entry command + sub commands', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    const command1 = {
+      // `name` property is defined at sub command
+      name: 'command1',
+      description: 'This is command1 (entry)',
+      args: {
+        foo: {
+          type: 'string',
+          description: 'The foo option',
+          short: 'f'
+        }
+      },
+      run: vi.fn()
+    }
+
+    const meta = {
+      name: 'gunshi',
+      description: 'Modern CLI tool',
+      version: '0.0.0'
+    }
+
+    const renderedEntry = await cli(['-h'], () => {}, { ...meta, subCommands: { command1 } })
+    const renderedCommand1 = await cli(['command1', '-h'], () => {}, {
+      ...meta,
+      subCommands: { command1 }
+    })
+
+    expect(renderedEntry).toMatchSnapshot('entry')
+    expect(renderedCommand1).toMatchSnapshot('command1')
+    expect(log()).toBeTruthy()
+  })
 })
 
 describe('custom generate usage', () => {

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -432,10 +432,21 @@ describe('lazy command', () => {
 })
 
 describe('auto generate usage', () => {
-  test('inline function', async () => {
+  test('loosely inline command', async () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
     const renderedUsage = await cli(['-h'], vi.fn())
+
+    const message = log()
+    expect(message).toMatchSnapshot('console')
+    expect(renderedUsage).toMatchSnapshot('rendered')
+  })
+
+  test('named entry command', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+    function entry() {} // `name` property is already required
+    const renderedUsage = await cli(['-h'], entry)
 
     const message = log()
     expect(message).toMatchSnapshot('console')
@@ -446,6 +457,7 @@ describe('auto generate usage', () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
     const renderedUsage = await cli(['-h'], {
+      // `name` property is not defined
       description: 'This is a loosely entry command',
       args: {
         foo: {
@@ -467,6 +479,7 @@ describe('auto generate usage', () => {
     const renderedUsage = await cli(
       ['-h'],
       {
+        // `name` property is defined
         name: 'command1',
         description: 'This is command1',
         args: {
@@ -508,6 +521,7 @@ describe('auto generate usage', () => {
       }
     } satisfies Args
     const entry = {
+      // `name` property is not defined at entry
       description: 'This is entry command',
       args: entryArgs,
       run: vi.fn()
@@ -521,6 +535,7 @@ describe('auto generate usage', () => {
       }
     } satisfies Args
     const command2 = {
+      // `name` property is defined at sub command
       description: 'This is command2',
       args: command2Args,
       run: vi.fn()
@@ -550,6 +565,7 @@ describe('auto generate usage', () => {
       }
     } satisfies Args
     const entry = {
+      // `name` property is defined at entry
       name: 'command1',
       description: 'This is command1 (entry)',
       args: entryArgs,
@@ -566,6 +582,7 @@ describe('auto generate usage', () => {
       }
     } satisfies Args
     const command2 = {
+      // `name` property is defined at sub command
       name: 'command2',
       description: 'This is command2',
       args: command2Args,
@@ -614,6 +631,48 @@ describe('auto generate usage', () => {
 
     const message = log()
     expect(message).toMatchSnapshot('console output')
+  })
+
+  test('named entry command + sub commands', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    function entry() {} // `name` property is already required
+
+    const command1 = {
+      // `name` property is defined at sub command
+      name: 'command1',
+      description: 'This is command1 (entry)',
+      args: {
+        foo: {
+          type: 'string',
+          description: 'The foo option',
+          short: 'f'
+        }
+      },
+      run: vi.fn()
+    }
+
+    const meta = {
+      name: 'gunshi',
+      description: 'Modern CLI tool',
+      version: '0.0.0'
+    }
+
+    const renderedEntry = await cli(['-h'], entry, { ...meta, subCommands: { command1 } })
+    const renderedExplicitEntry = await cli(['entry', '-h'], entry, {
+      ...meta,
+      subCommands: { command1 }
+    })
+    const renderedCommand1 = await cli(['command1', '-h'], entry, {
+      ...meta,
+      subCommands: { command1 }
+    })
+
+    expect(renderedEntry).toMatchSnapshot('entry')
+    expect(renderedExplicitEntry).toMatchSnapshot('explicit entry')
+    expect(renderedCommand1).toMatchSnapshot('command1')
+    expect(log()).toBeTruthy()
   })
 })
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -180,7 +180,7 @@ function createInitialSubCommands<G extends GunshiParamsConstraint>(
     } else if (typeof entryCmd === 'function') {
       // for command runner
       const name = entryCmd.name || ANONYMOUS_COMMAND_NAME
-      subCommands.set(entryCmd.name, {
+      subCommands.set(name, {
         run: entryCmd as CommandRunner<G>,
         name,
         entry: true

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -172,9 +172,18 @@ function createInitialSubCommands<G extends GunshiParamsConstraint>(
   }
 
   // add entry command to sub commands if there are sub commands
-  if (hasSubCommands && (isLazyCommand(entryCmd) || typeof entryCmd === 'object')) {
-    entryCmd.entry = true
-    subCommands.set(resolveEntryName(entryCmd as LazyCommand<G> | Command<G>), entryCmd)
+  if (hasSubCommands) {
+    if (isLazyCommand(entryCmd) || typeof entryCmd === 'object') {
+      entryCmd.entry = true
+      subCommands.set(resolveEntryName(entryCmd as LazyCommand<G> | Command<G>), entryCmd)
+    } else if (typeof entryCmd === 'function' && entryCmd.name) {
+      // command runner
+      subCommands.set(entryCmd.name, {
+        run: entryCmd as CommandRunner<G>,
+        name: entryCmd.name,
+        entry: true
+      })
+    }
   }
 
   return subCommands

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -174,13 +174,15 @@ function createInitialSubCommands<G extends GunshiParamsConstraint>(
   // add entry command to sub commands if there are sub commands
   if (hasSubCommands) {
     if (isLazyCommand(entryCmd) || typeof entryCmd === 'object') {
+      // for command
       entryCmd.entry = true
       subCommands.set(resolveEntryName(entryCmd as LazyCommand<G> | Command<G>), entryCmd)
-    } else if (typeof entryCmd === 'function' && entryCmd.name) {
-      // command runner
+    } else if (typeof entryCmd === 'function') {
+      // for command runner
+      const name = entryCmd.name || ANONYMOUS_COMMAND_NAME
       subCommands.set(entryCmd.name, {
         run: entryCmd as CommandRunner<G>,
-        name: entryCmd.name,
+        name,
         entry: true
       })
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Function-based entry commands are now treated as first-class entries and can be invoked alongside sub-commands, including support for anonymous (unnamed) entries.
  - More consistent usage output and clearer console messages when entry or sub-command names are present or omitted.

- **Tests**
  - Expanded coverage for entry/sub-command interactions across many invocation scenarios.
  - Added usage snapshot and console output assertions for named and anonymous entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->