### PR TITLE
feat(plugin-renderer): improve positional argument with `multiple: true` usage display

### DIFF
--- a/packages/docs/src/guide/essentials/declarative.md
+++ b/packages/docs/src/guide/essentials/declarative.md
@@ -165,7 +165,7 @@ Each option can have the following properties:
   <!-- eslint-enable markdown/no-missing-label-refs -->
 - `description`: A description of what the option does
 - `default`: Default value if the option is not provided
-- `required`: Set to `true` if the option is required (Note: Positional arguments defined with `type: 'positional'` are implicitly required by the parser).
+- `required`: Set to `true` if the option is required (Note: Positional arguments defined with `type: 'positional'` without `multiple: true` are implicitly required by the parser).
 - `multiple`: Set to `true` if multiple option values are allowed
 - `toKebab`: Set to `true` to convert camelCase argument names to kebab-case in help text and command-line usage
 - `parse`: A function to parse and validate the argument value. Required when `type` is 'custom'

--- a/packages/plugin-renderer/src/__snapshots__/usage.test.ts.snap
+++ b/packages/plugin-renderer/src/__snapshots__/usage.test.ts.snap
@@ -97,6 +97,30 @@ OPTIONS:
 "
 `;
 
+exports[`multiple positional arguments 1`] = `
+"A test command
+
+USAGE:
+  cmd1 test <foo> [<bar> ...]
+
+ARGUMENTS:
+  foo           The foo argument
+  bar           The bar argument
+"
+`;
+
+exports[`multiple positional arguments with required 1`] = `
+"A test command
+
+USAGE:
+  cmd1 test <foo> <bar> [<bar> ...]
+
+ARGUMENTS:
+  foo           The foo argument
+  bar           The bar argument
+"
+`;
+
 exports[`no arguments 1`] = `
 "A test command
 

--- a/packages/plugin-renderer/src/usage.test.ts
+++ b/packages/plugin-renderer/src/usage.test.ts
@@ -323,6 +323,93 @@ test('mixed positionals and optionals', async () => {
   expect(await renderUsage<WithI18nAndRenderer>(ctx)).toMatchSnapshot()
 })
 
+test('multiple positional arguments', async () => {
+  const command = {
+    args: {
+      foo: {
+        type: 'positional',
+        description: 'The foo argument'
+      },
+      bar: {
+        type: 'positional',
+        description: 'The bar argument',
+        multiple: true
+      }
+    },
+    name: 'test',
+    description: 'A test command',
+    run: NOOP
+  } as Command<GunshiParams<{ args: Args }>>
+
+  const ctx = await createCommandContext({
+    args: command.args!,
+    explicit: {},
+    values: {},
+    positionals: [],
+    rest: [],
+    argv: [],
+    tokens: [], // dummy, due to test
+    omitted: false,
+    callMode: 'subCommand',
+    command,
+    extensions: {
+      [i18nPlugin.id]: i18nPlugin.extension,
+      [rendererPlugin.id]: rendererPlugin.extension
+    },
+    cliOptions: {
+      cwd: '/path/to/cmd1',
+      version: '0.0.0',
+      name: 'cmd1'
+    }
+  })
+
+  expect(await renderUsage<WithI18nAndRenderer>(ctx)).toMatchSnapshot()
+})
+
+test('multiple positional arguments with required', async () => {
+  const command = {
+    args: {
+      foo: {
+        type: 'positional',
+        description: 'The foo argument'
+      },
+      bar: {
+        type: 'positional',
+        description: 'The bar argument',
+        multiple: true,
+        required: true
+      }
+    },
+    name: 'test',
+    description: 'A test command',
+    run: NOOP
+  } as Command<GunshiParams<{ args: Args }>>
+
+  const ctx = await createCommandContext({
+    args: command.args!,
+    explicit: {},
+    values: {},
+    positionals: [],
+    rest: [],
+    argv: [],
+    tokens: [], // dummy, due to test
+    omitted: false,
+    callMode: 'subCommand',
+    command,
+    extensions: {
+      [i18nPlugin.id]: i18nPlugin.extension,
+      [rendererPlugin.id]: rendererPlugin.extension
+    },
+    cliOptions: {
+      cwd: '/path/to/cmd1',
+      version: '0.0.0',
+      name: 'cmd1'
+    }
+  })
+
+  expect(await renderUsage<WithI18nAndRenderer>(ctx)).toMatchSnapshot()
+})
+
 test('no examples', async () => {
   const command = {
     args: {

--- a/packages/plugin-renderer/src/usage.ts
+++ b/packages/plugin-renderer/src/usage.ts
@@ -552,7 +552,16 @@ async function generatePositionalArgsUsage<
 function generatePositionalSymbols(args: Args): string {
   return hasPositionalArgs(args)
     ? getPositionalArgs(args)
-        .map(([name]) => `<${name}>`)
+        .map(([name, arg]) => {
+          const elements: string[] = []
+          if (!arg.multiple || arg.required) {
+            elements.push(`<${name}>`)
+          }
+          if (arg.multiple) {
+            elements.push(`[<${name}> ...]`)
+          }
+          return elements.join(' ')
+        })
         .join(' ')
     : ''
 }


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR improves the help text when there are positional arguments with `multiple: true`.

### Linked Issues

close #431

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

If the output format is not what you want, please let me know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of positional arguments in usage output to correctly display optional and multiple argument syntax.

* **Documentation**
  * Clarified when positional arguments are implicitly required based on their configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->