### PR TITLE
chore(docs): remove Cursor rules support

### DIFF
--- a/packages/docs/bin/init.js
+++ b/packages/docs/bin/init.js
@@ -39,18 +39,11 @@ When creating command-line interfaces, use the \`${SKILL_NAME}\` skill.
 
 const cwd = process.cwd()
 const CLAUDE_SKILL_PATH = path.join(cwd, `.claude/skills/${SKILL_NAME}/SKILL.md`)
-const CURSOR_RULES_PATH = path.join(cwd, `.cursor/rules/${SKILL_NAME}.mdc`)
 const CLAUDE_MD_FILEPATH = path.join(cwd, 'CLAUDE.md')
 
-const [hasClaudeCode, hasCursor, hasCursorCli] = await Promise.all(
-  ['claude', 'cursor', 'cursor-agent'].map(cmd =>
-    x('which', [cmd], { throwOnError: false })
-      .then(({ stdout }) => stdout.trim().length > 0)
-      .catch(() => false)
-  )
-)
-
-const hasCursorEditors = hasCursor || hasCursorCli
+const hasClaudeCode = await x('which', ['claude'], { throwOnError: false })
+  .then(({ stdout }) => stdout.trim().length > 0)
+  .catch(() => false)
 
 // Helper function to check if CLAUDE.md already contains Gunshi instructions
 async function hasGunshiInstruction(filePath) {
@@ -74,9 +67,7 @@ async function fileExists(filePath) {
   }
 }
 
-const isWindows = process.platform === 'win32'
-
-// Claude Code setup (always create as the master file):
+// Claude Code setup:
 // - Create skill file at .claude/skills/use-gunshi-cli/SKILL.md
 // - Update or create CLAUDE.md with instruction to use the skill
 //   (skip if Gunshi is already mentioned to avoid duplication)
@@ -102,26 +93,6 @@ if (hasClaudeCode) {
     }
   } else {
     console.log(`Gunshi instructions already exist in ${CLAUDE_MD_FILEPATH}, skipping`)
-  }
-}
-
-// Cursor setup:
-// - On Linux/macOS: create symlink to Claude skill file
-// - On Windows: copy the file (symlinks require admin privileges)
-if (hasCursorEditors) {
-  await x('mkdir', ['-p', path.dirname(CURSOR_RULES_PATH)])
-
-  if (isWindows) {
-    // On Windows, just copy the file (symlinks require admin privileges)
-    await fs.writeFile(CURSOR_RULES_PATH, SKILL_CONTENT, 'utf8')
-    console.log(`Created Cursor rule at ${CURSOR_RULES_PATH}`)
-  } else {
-    // Create relative symlink from Cursor rules to Claude skill
-    const relativeTarget = path.relative(path.dirname(CURSOR_RULES_PATH), CLAUDE_SKILL_PATH)
-    // Remove existing file/symlink if it exists
-    await fs.rm(CURSOR_RULES_PATH, { force: true })
-    await fs.symlink(relativeTarget, CURSOR_RULES_PATH)
-    console.log(`Created Cursor rule symlink at ${CURSOR_RULES_PATH} -> ${relativeTarget}`)
   }
 }
 

--- a/packages/docs/src/guide/introduction/setup.md
+++ b/packages/docs/src/guide/introduction/setup.md
@@ -33,7 +33,7 @@ bun add gunshi
 
 ## LLM-Assisted Development
 
-Gunshi provides tooling to integrate with AI coding assistants such as [Claude Code](https://claude.ai/code) and [Cursor](https://cursor.com/).
+Gunshi provides tooling to integrate with AI coding assistants such as [Claude Code](https://claude.ai/code).
 
 ### Automatic Setup (Recommended)
 
@@ -59,10 +59,7 @@ bun x @gunshi/docs
 
 :::
 
-This command automatically configures:
-
-- [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for Claude Code
-- [Cursor rules](https://docs.cursor.com/context/rules-for-ai) for Cursor
+This command automatically configures [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for Claude Code.
 
 ### Manual Setup
 
@@ -90,7 +87,7 @@ bun add -D @gunshi/docs
 
 This package includes guide content and API references as markdown files in [llms.txt](https://llmstxt.org/) format.
 
-Then add the following to your AI agent's configuration file (e.g., `CLAUDE.md` and `.cursor/rules/use-gunshi-cli.md`):
+Then add the following to your AI agent's configuration file (e.g., `CLAUDE.md`):
 
 ```md
 # CLI Development with Gunshi

--- a/packages/docs/src/release/v0.27.md
+++ b/packages/docs/src/release/v0.27.md
@@ -182,7 +182,7 @@ Use cases:
 
 ### `@gunshi/docs` - LLM-Assisted Development (Experimental)
 
-New package for integrating with AI coding assistants such as [Claude Code](https://claude.ai/code) and [Cursor](https://cursor.com/):
+New package for integrating with AI coding assistants such as [Claude Code](https://claude.ai/code):
 
 ```sh
 npx @gunshi/docs
@@ -191,7 +191,6 @@ npx @gunshi/docs
 This command automatically configures:
 
 - [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) at `.claude/skills/use-gunshi-cli/SKILL.md`
-- [Cursor rules](https://docs.cursor.com/context/rules-for-ai) at `.cursor/rules/use-gunshi-cli.mdc`
 - Updates `CLAUDE.md` with instructions to use the Gunshi skill
 
 Optionally, it can also install `gunshi` and `@gunshi/docs` packages for you.


### PR DESCRIPTION
## Summary

Remove Cursor editor integration from the @gunshi/docs package.

## Why

Cursor can now read `CLAUDE.md` and Claude Code skills directly, making separate Cursor rules configuration redundant. This simplifies the LLM-assisted development setup by maintaining only the Claude Code skills as the single source of truth.
<img width="723" height="331" alt="SCR-20251218-lpvy" src="https://github.com/user-attachments/assets/c8a53123-1683-4c02-b806-bb1435440880" />



## What Changed

- Remove Cursor/cursor-agent detection in init.js
- Remove .cursor/rules symlink/file creation logic
- Remove Windows-specific handling for Cursor rules
- Update setup.md to reference only Claude Code
- Update v0.27 release notes to remove Cursor mentions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined setup documentation and automatic installation process
  * Updated guides to focus exclusively on Claude Code integration
  * Simplified manual configuration instructions for faster onboarding

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->