### PR TITLE
fix(#499): Parse arguments for lazy loaded command objects

### DIFF
--- a/e2e/fixture/essentials/lazy-async/dynamic-command/config-help.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/config-help.snap
@@ -8,4 +8,5 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Verbose output
 

--- a/e2e/fixture/essentials/lazy-async/dynamic-command/config.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/config.snap
@@ -1,3 +1,4 @@
 my-cli (my-cli v1.0.0)
 
 Running in normal mode
+Verbose: true

--- a/e2e/fixture/essentials/lazy-async/dynamic-command/debug-config-help.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/debug-config-help.snap
@@ -8,4 +8,5 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Verbose output (DEBUG mode)
 

--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -504,6 +504,20 @@ OPTIONS:
 "
 `;
 
+exports[`github issues > #499 - lazy command args not parsed > lazy sub-command usage includes argument definitions 1`] = `
+"my-cli (my-cli v1.0.0)
+Say hello
+
+USAGE:
+  my-cli hello <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+  --name [name]          The name of the person to say hello to (default: World)
+"
+`;
+
 exports[`lazy command > command loading > config-command 1`] = `
 "lazy-command-loading (lazy-command-loading v1.0.0)
 Loaded configured command
@@ -514,6 +528,7 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Enable verbose output (default: false)
 "
 `;
 


### PR DESCRIPTION
### Description

Command line arguments are not being parsed for lazy-loaded sub-commands as described in [Alternative Loader Return Types](https://gunshi.dev/guide/essentials/lazy-async#alternative-loader-return-types). The arguments are also not showing up in the usage. The issue was that the command wasn't resolved until after the arguments were resolved.

### Linked Issues

* #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy-loaded sub-command argument handling and defaults
  * Fixed usage information generation for lazy sub-commands

* **Tests**
  * Added test suite for lazy sub-command argument parsing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->