### PR TITLE
feat(gunshi): add onResolveValue lifecycle hook to CliOptions

### DIFF
--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -2003,7 +2003,11 @@ describe('nested sub-commands', () => {
 
 describe('onResolveValue hook', () => {
   test('required arg supplied only by onResolveValue clears validationError', async () => {
-    const mockFn = vi.fn()
+    const runSpy = vi.fn()
+    const hookSpy = vi.fn(sources => ({
+      ...sources.values,
+      token: 'secret-from-env'
+    }))
 
     await cli(
       // no --token on the CLI
@@ -2012,18 +2016,22 @@ describe('onResolveValue hook', () => {
         args: {
           token: { type: 'string', required: true }
         },
-        run: mockFn
+        run: runSpy
       },
       {
-        onResolveValue: sources => ({
-          ...sources.values,
-          token: 'secret-from-env'
-        })
+        onResolveValue: hookSpy
       }
     )
 
-    expect(mockFn).toHaveBeenCalledOnce()
-    const ctx = mockFn.mock.calls[0][0]
+    // hook must be called exactly once with a well-formed sources payload
+    expect(hookSpy).toHaveBeenCalledOnce()
+    const [sources] = hookSpy.mock.calls[0]
+    expect(sources).toHaveProperty('values')
+    expect(sources).toHaveProperty('explicit')
+    expect(typeof sources.explicit.token).toBe('boolean')
+
+    expect(runSpy).toHaveBeenCalledOnce()
+    const ctx = runSpy.mock.calls[0][0]
     expect(ctx.values.token).toBe('secret-from-env')
     // validation error must be cleared because the hook satisfied the requirement
     expect(ctx.validationError).toBeUndefined()

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -2032,6 +2032,7 @@ describe('onResolveValue hook', () => {
   test('validationError remains when onResolveValue does not satisfy required arg', async () => {
     const utils = await import('./utils.ts')
     const log = defineMockLog(utils)
+    const runSpy = vi.fn()
 
     await cli(
       [],
@@ -2039,7 +2040,7 @@ describe('onResolveValue hook', () => {
         args: {
           token: { type: 'string', required: true }
         },
-        run: vi.fn()
+        run: runSpy
       },
       {
         // hook returns undefined — falls back to original (still missing token)
@@ -2047,7 +2048,8 @@ describe('onResolveValue hook', () => {
       }
     )
 
-    // command runner is not invoked; error is rendered instead
+    // command runner must not be invoked; error is rendered instead
+    expect(runSpy).not.toHaveBeenCalled()
     expect(log()).toMatch(/token/)
   })
 })

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -2000,3 +2000,54 @@ describe('nested sub-commands', () => {
     )
   })
 })
+
+describe('onResolveValue hook', () => {
+  test('required arg supplied only by onResolveValue clears validationError', async () => {
+    const mockFn = vi.fn()
+
+    await cli(
+      // no --token on the CLI
+      [],
+      {
+        args: {
+          token: { type: 'string', required: true }
+        },
+        run: mockFn
+      },
+      {
+        onResolveValue: sources => ({
+          ...sources.values,
+          token: 'secret-from-env'
+        })
+      }
+    )
+
+    expect(mockFn).toHaveBeenCalledOnce()
+    const ctx = mockFn.mock.calls[0][0]
+    expect(ctx.values.token).toBe('secret-from-env')
+    // validation error must be cleared because the hook satisfied the requirement
+    expect(ctx.validationError).toBeUndefined()
+  })
+
+  test('validationError remains when onResolveValue does not satisfy required arg', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await cli(
+      [],
+      {
+        args: {
+          token: { type: 'string', required: true }
+        },
+        run: vi.fn()
+      },
+      {
+        // hook returns undefined — falls back to original (still missing token)
+        onResolveValue: () => undefined
+      }
+    )
+
+    // command runner is not invoked; error is rendered instead
+    expect(log()).toMatch(/token/)
+  })
+})

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -9,7 +9,7 @@ import { createCommandContext } from '../context.ts'
 import { createDecorators } from '../decorators.ts'
 import { createPluginContext } from '../plugin/context.ts'
 import { resolveDependencies } from '../plugin/dependency.ts'
-import { resolveValue } from '../resolver.ts'
+import { revalidateError, resolveValue } from '../resolver.ts'
 import { create, getCommandSubCommands, isLazyCommand, resolveLazyCommand } from '../utils.ts'
 
 import type { Decorators } from '../decorators.ts'
@@ -86,6 +86,11 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
   const omitted = resolved.omitted
 
   const resolvedValues = await resolveValue(options.onResolveValue, values, explicit)
+  // Re-run validation against the hook-resolved values so that required args
+  // filled in by the hook (e.g. from config/env) no longer produce a false error.
+  const resolvedError = options.onResolveValue
+    ? revalidateError(error, args, resolvedValues)
+    : error
 
   // override subCommands with level-specific sub-commands for rendering
   if (levelSubCommands) {
@@ -109,7 +114,7 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
     commandPath,
     command: resolvedCommand,
     extensions: getPluginExtensions(resolvedPlugins),
-    validationError: error,
+    validationError: resolvedError,
     cliOptions: cliOptions
   })
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -9,6 +9,7 @@ import { createCommandContext } from '../context.ts'
 import { createDecorators } from '../decorators.ts'
 import { createPluginContext } from '../plugin/context.ts'
 import { resolveDependencies } from '../plugin/dependency.ts'
+import { resolveValue } from '../resolver.ts'
 import { create, getCommandSubCommands, isLazyCommand, resolveLazyCommand } from '../utils.ts'
 
 import type { Decorators } from '../decorators.ts'
@@ -84,6 +85,8 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
   })
   const omitted = resolved.omitted
 
+  const resolvedValues = await resolveValue(options.onResolveValue, values, explicit)
+
   // override subCommands with level-specific sub-commands for rendering
   if (levelSubCommands) {
     cliOptions.subCommands = levelSubCommands
@@ -96,7 +99,7 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
   const commandContext = await createCommandContext({
     args,
     explicit,
-    values,
+    values: resolvedValues,
     positionals,
     rest,
     argv,

--- a/packages/gunshi/src/resolver.test-d.ts
+++ b/packages/gunshi/src/resolver.test-d.ts
@@ -1,0 +1,67 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { expectTypeOf, test } from 'vitest'
+import type { Args, ArgExplicitlyProvided, ArgValues } from 'args-tokens'
+import type { Awaitable, ValueResolutionSources } from './types.ts'
+
+type StringArg = { type: 'string' }
+type NumberArg = { type: 'number' }
+type BooleanArg = { type: 'boolean' }
+
+type MyArgs = Args & {
+  name: StringArg
+  port: NumberArg
+  debug: BooleanArg
+}
+
+test('ValueResolutionSources.values is typed as ArgValues<A>', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['values']>().toEqualTypeOf<ArgValues<MyArgs>>()
+})
+
+test('ValueResolutionSources.explicit is typed as ArgExplicitlyProvided<A>', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['explicit']>().toEqualTypeOf<ArgExplicitlyProvided<MyArgs>>()
+})
+
+test('sources.values.name resolves to string | undefined', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['values']['name']>().toEqualTypeOf<string | undefined>()
+})
+
+test('sources.values.port resolves to number | undefined', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['values']['port']>().toEqualTypeOf<number | undefined>()
+})
+
+test('sources.values.debug resolves to boolean | undefined', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['values']['debug']>().toEqualTypeOf<boolean | undefined>()
+})
+
+test('sources.explicit flags resolve to boolean', () => {
+  type Sources = ValueResolutionSources<MyArgs>
+  expectTypeOf<Sources['explicit']['name']>().toEqualTypeOf<boolean>()
+  expectTypeOf<Sources['explicit']['port']>().toEqualTypeOf<boolean>()
+  expectTypeOf<Sources['explicit']['debug']>().toEqualTypeOf<boolean>()
+})
+
+test('onResolveValue hook return type is Awaitable<ArgValues<A> | undefined>', () => {
+  type Hook = (sources: ValueResolutionSources<MyArgs>) => Awaitable<ArgValues<MyArgs> | undefined>
+  // Sync return: ArgValues<MyArgs>
+  expectTypeOf<ReturnType<Hook>>().toEqualTypeOf<Awaitable<ArgValues<MyArgs> | undefined>>()
+})
+
+test('onResolveValue hook accepts ValueResolutionSources<A> as parameter', () => {
+  type Hook = (sources: ValueResolutionSources<MyArgs>) => Awaitable<ArgValues<MyArgs> | undefined>
+  expectTypeOf<Parameters<Hook>[0]>().toEqualTypeOf<ValueResolutionSources<MyArgs>>()
+})
+
+test('ValueResolutionSources defaults A to Args when no type parameter given', () => {
+  type DefaultSources = ValueResolutionSources
+  expectTypeOf<DefaultSources['values']>().toEqualTypeOf<ArgValues<Args>>()
+  expectTypeOf<DefaultSources['explicit']>().toEqualTypeOf<ArgExplicitlyProvided<Args>>()
+})

--- a/packages/gunshi/src/resolver.test.ts
+++ b/packages/gunshi/src/resolver.test.ts
@@ -3,9 +3,10 @@
  * @license MIT
  */
 
+import { ArgResolveError } from 'args-tokens'
 import { describe, expect, test, vi } from 'vitest'
-import { resolveValue } from './resolver.ts'
-import type { Args, ArgValues, ArgExplicitlyProvided } from 'args-tokens'
+import { revalidateError, resolveValue } from './resolver.ts'
+import type { Args, ArgExplicitlyProvided, ArgValues } from 'args-tokens'
 
 type TestArgs = Args & {
   name: { type: 'string' }
@@ -99,5 +100,100 @@ describe('resolveValue', () => {
     const result = await resolveValue(hook, values, explicit)
 
     expect(result).toBe(overridden)
+  })
+})
+
+describe('revalidateError', () => {
+  const requiredArgs = {
+    name: { type: 'string' as const, required: true as const },
+    port: { type: 'number' as const }
+  }
+
+  test('should return undefined when original error is undefined', () => {
+    const result = revalidateError(undefined, requiredArgs, { name: 'foo', port: 3000 })
+    expect(result).toBeUndefined()
+  })
+
+  test('should clear required error when resolved value is now present', () => {
+    const schema = requiredArgs.name
+    const requiredError = new ArgResolveError(
+      "Optional argument '--name' is required",
+      'name',
+      'required',
+      schema
+    )
+    const error = new AggregateError([requiredError])
+
+    // hook filled in the required arg
+    const result = revalidateError(error, requiredArgs, { name: 'from-config', port: 3000 })
+
+    expect(result).toBeUndefined()
+  })
+
+  test('should keep required error when resolved value is still missing', () => {
+    const schema = requiredArgs.name
+    const requiredError = new ArgResolveError(
+      "Optional argument '--name' is required",
+      'name',
+      'required',
+      schema
+    )
+    const error = new AggregateError([requiredError])
+
+    // hook did not fill in the required arg
+    const result = revalidateError(error, requiredArgs, { port: 3000 } as ArgValues<
+      typeof requiredArgs
+    >)
+
+    expect(result).toBeInstanceOf(AggregateError)
+    expect(result!.errors).toHaveLength(1)
+    expect(result!.errors[0]).toBe(requiredError)
+  })
+
+  test('should keep non-required errors (type, conflict) unchanged', () => {
+    const schema = requiredArgs.port
+    const typeError = new ArgResolveError(
+      "Optional argument '--port' should be 'number'",
+      'port',
+      'type',
+      schema
+    )
+    const error = new AggregateError([typeError])
+
+    // values look resolved but the type error should still remain
+    const result = revalidateError(error, requiredArgs, { name: 'foo', port: 3000 })
+
+    expect(result).toBeInstanceOf(AggregateError)
+    expect(result!.errors).toHaveLength(1)
+    expect(result!.errors[0]).toBe(typeError)
+  })
+
+  test('should partially clear errors when only some required args are resolved', () => {
+    const mixedArgs = {
+      name: { type: 'string' as const, required: true as const },
+      config: { type: 'string' as const, required: true as const }
+    }
+    const nameError = new ArgResolveError(
+      "Optional argument '--name' is required",
+      'name',
+      'required',
+      mixedArgs.name
+    )
+    const configError = new ArgResolveError(
+      "Optional argument '--config' is required",
+      'config',
+      'required',
+      mixedArgs.config
+    )
+    const error = new AggregateError([nameError, configError])
+
+    // hook filled in 'name' but not 'config'
+    const result = revalidateError(error, mixedArgs, { name: 'filled' } as ArgValues<
+      typeof mixedArgs
+    >)
+
+    expect(result).toBeInstanceOf(AggregateError)
+    expect(result!.errors).toHaveLength(1)
+    expect(result!.errors[0]).toBe(configError)
   })
 })

--- a/packages/gunshi/src/resolver.test.ts
+++ b/packages/gunshi/src/resolver.test.ts
@@ -14,6 +14,10 @@ type TestArgs = Args & {
   debug: { type: 'boolean' }
 }
 
+type NestedArgs = Args & {
+  name: { type: 'string' }
+}
+
 const values: ArgValues<TestArgs> = {
   name: 'default-name',
   port: 3000,
@@ -91,6 +95,51 @@ describe('resolveValue', () => {
     // Fallback must be the unmodified original
     expect(result).toBe(inputValues)
     expect(result.name).toBe('original')
+  })
+
+  test('should preserve original values when hook mutates a nested object on the snapshot and returns undefined', async () => {
+    // Object.freeze only freezes the top-level properties, so nested objects/arrays
+    // are still mutable. The fallback must still return the unmodified original reference.
+    const nested = { extra: 'original' }
+    const inputValues = { name: 'original' } as ArgValues<NestedArgs>
+    // Attach a nested object outside the type so we can observe mutation attempts
+    ;(inputValues as Record<string, unknown>)['meta'] = nested
+
+    const nestedExplicit: ArgExplicitlyProvided<NestedArgs> = { name: false }
+
+    const hook = vi
+      .fn()
+      .mockImplementation(
+        (sources: { values: ArgValues<NestedArgs> & Record<string, unknown> }) => {
+          // Top-level freeze blocks this; nested objects are not frozen
+          try {
+            ;(sources.values as Record<string, unknown>)['name'] = 'mutated-top'
+          } catch {
+            // Silently ignore TypeError from frozen top-level in strict mode
+          }
+          // Mutate nested object — shallow freeze does NOT protect this
+          const meta = sources.values['meta'] as Record<string, unknown> | undefined
+          if (meta) {
+            meta['extra'] = 'mutated-nested'
+          }
+          return undefined
+        }
+      )
+
+    const result = await resolveValue(
+      hook as unknown as Parameters<typeof resolveValue>[0],
+      inputValues,
+      nestedExplicit as unknown as ArgExplicitlyProvided<NestedArgs>
+    )
+
+    // Fallback reference must be the unmodified original
+    expect(result).toBe(inputValues)
+    // Top-level string was protected by Object.freeze
+    expect(result.name).toBe('original')
+    // Nested object was mutated through the shallow-frozen snapshot —
+    // this documents the known limitation of Object.freeze and ensures the
+    // suite catches any regression if the implementation moves to deep-freeze.
+    expect(nested.extra).toBe('mutated-nested')
   })
 
   test('should support synchronous hook', async () => {

--- a/packages/gunshi/src/resolver.test.ts
+++ b/packages/gunshi/src/resolver.test.ts
@@ -39,7 +39,12 @@ describe('resolveValue', () => {
 
     expect(result).toBe(overridden)
     expect(hook).toHaveBeenCalledOnce()
-    expect(hook).toHaveBeenCalledWith({ values, explicit })
+    // hook receives a frozen snapshot (not the original reference), but with equal values
+    const [calledSources] = hook.mock.calls[0]
+    expect(calledSources.values).toEqual(values)
+    expect(calledSources.values).not.toBe(values)
+    expect(Object.isFrozen(calledSources.values)).toBe(true)
+    expect(calledSources.explicit).toBe(explicit)
   })
 
   test('should fall back to original values when hook returns undefined', async () => {
@@ -61,7 +66,30 @@ describe('resolveValue', () => {
 
     await resolveValue(hook, values, explicitWithPort)
 
-    expect(hook).toHaveBeenCalledWith({ values, explicit: explicitWithPort })
+    const [calledSources] = hook.mock.calls[0]
+    expect(calledSources.values).toEqual(values)
+    expect(calledSources.explicit).toBe(explicitWithPort)
+  })
+
+  test('should return original values when hook mutates snapshot and returns undefined', async () => {
+    const original = { name: 'original', port: 3000, debug: false }
+    const inputValues: ArgValues<TestArgs> = { ...original }
+
+    const hook = vi.fn().mockImplementation((sources: { values: ArgValues<TestArgs> }) => {
+      // Attempt to mutate the snapshot passed to the hook
+      try {
+        ;(sources.values as Record<string, unknown>)['name'] = 'mutated'
+      } catch {
+        // Silently ignore TypeError from frozen object in strict mode
+      }
+      return undefined
+    })
+
+    const result = await resolveValue(hook, inputValues, explicit)
+
+    // Fallback must be the unmodified original
+    expect(result).toBe(inputValues)
+    expect(result.name).toBe('original')
   })
 
   test('should support synchronous hook', async () => {

--- a/packages/gunshi/src/resolver.test.ts
+++ b/packages/gunshi/src/resolver.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { describe, expect, test, vi } from 'vitest'
+import { resolveValue } from './resolver.ts'
+import type { Args, ArgValues, ArgExplicitlyProvided } from 'args-tokens'
+
+type TestArgs = Args & {
+  name: { type: 'string' }
+  port: { type: 'number' }
+  debug: { type: 'boolean' }
+}
+
+const values: ArgValues<TestArgs> = {
+  name: 'default-name',
+  port: 3000,
+  debug: false
+}
+
+const explicit: ArgExplicitlyProvided<TestArgs> = {
+  name: false,
+  port: false,
+  debug: false
+}
+
+describe('resolveValue', () => {
+  test('should return original values when hook is undefined', async () => {
+    const result = await resolveValue(undefined, values, explicit)
+    expect(result).toBe(values)
+  })
+
+  test('should return hook result when hook returns a value', async () => {
+    const overridden: ArgValues<TestArgs> = { name: 'from-config', port: 8080, debug: true }
+    const hook = vi.fn().mockResolvedValue(overridden)
+
+    const result = await resolveValue(hook, values, explicit)
+
+    expect(result).toBe(overridden)
+    expect(hook).toHaveBeenCalledOnce()
+    expect(hook).toHaveBeenCalledWith({ values, explicit })
+  })
+
+  test('should fall back to original values when hook returns undefined', async () => {
+    const hook = vi.fn().mockResolvedValue(undefined)
+
+    const result = await resolveValue(hook, values, explicit)
+
+    expect(result).toBe(values)
+    expect(hook).toHaveBeenCalledOnce()
+  })
+
+  test('should pass correct sources to hook', async () => {
+    const explicitWithPort: ArgExplicitlyProvided<TestArgs> = {
+      name: false,
+      port: true,
+      debug: false
+    }
+    const hook = vi.fn().mockResolvedValue(undefined)
+
+    await resolveValue(hook, values, explicitWithPort)
+
+    expect(hook).toHaveBeenCalledWith({ values, explicit: explicitWithPort })
+  })
+
+  test('should support synchronous hook', async () => {
+    const overridden: ArgValues<TestArgs> = { name: 'sync-result', port: 9000, debug: true }
+    const hook = vi.fn().mockReturnValue(overridden)
+
+    const result = await resolveValue(hook, values, explicit)
+
+    expect(result).toBe(overridden)
+  })
+})

--- a/packages/gunshi/src/resolver.ts
+++ b/packages/gunshi/src/resolver.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+import { ArgResolveError } from 'args-tokens'
 import type { Args, ArgExplicitlyProvided, ArgValues } from 'args-tokens'
 import type { Awaitable, ValueResolutionSources } from './types.ts'
 
@@ -28,4 +29,44 @@ export async function resolveValue<A extends Args>(
   // the original is preserved as the fallback when the hook returns undefined.
   const snapshot = Object.freeze({ ...values }) as ArgValues<A>
   return (await hook({ values: snapshot, explicit })) ?? values
+}
+
+/**
+ * Recompute the validation error after the onResolveValue hook has run.
+ *
+ * Required-argument errors are dropped for any key whose value is now
+ * non-nullish in `resolvedValues`; all other errors (type, conflict, etc.)
+ * are kept unchanged.
+ *
+ * @typeParam A - The Args type from command definition
+ *
+ * @param error - The AggregateError produced by resolveArgs before the hook ran
+ * @param args - The Args schema used during parsing (used to map schema references back to raw keys)
+ * @param resolvedValues - The final values after the hook has been applied
+ * @returns A new AggregateError containing only the still-failing errors, or undefined if all errors are resolved
+ */
+export function revalidateError<A extends Args>(
+  error: AggregateError | undefined,
+  args: A,
+  resolvedValues: ArgValues<A>
+): AggregateError | undefined {
+  if (!error) return undefined
+
+  const values = resolvedValues as Record<string, unknown>
+
+  // Build a reverse map from schema object reference → rawArg key so that we
+  // can look up keys without having to re-apply kebab-case conversion logic.
+  const schemaToKey = new Map<object, string>()
+  for (const [rawArg, schema] of Object.entries(args)) {
+    schemaToKey.set(schema, rawArg)
+  }
+
+  const remaining = (error.errors as Error[]).filter(err => {
+    if (!(err instanceof ArgResolveError) || err.type !== 'required') return true
+    const rawArg = schemaToKey.get(err.schema)
+    if (rawArg == null) return true // Cannot match schema — keep the error conservatively
+    return values[rawArg] == null
+  })
+
+  return remaining.length > 0 ? new AggregateError(remaining) : undefined
 }

--- a/packages/gunshi/src/resolver.ts
+++ b/packages/gunshi/src/resolver.ts
@@ -1,0 +1,28 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import type { Args, ArgExplicitlyProvided, ArgValues } from 'args-tokens'
+import type { Awaitable, ValueResolutionSources } from './types.ts'
+
+/**
+ * Apply the onResolveValue hook if provided, falling back to the original values.
+ *
+ * @typeParam A - The Args type from command definition
+ *
+ * @param hook - The onResolveValue hook from CLI options, if registered
+ * @param values - Parsed argument values with schema defaults filled in
+ * @param explicit - Map of which keys were explicitly provided via CLI
+ * @returns The resolved values from the hook, or the original values if no hook or hook returns undefined
+ */
+export async function resolveValue<A extends Args>(
+  hook: ((sources: ValueResolutionSources<A>) => Awaitable<ArgValues<A> | undefined>) | undefined,
+  values: ArgValues<A>,
+  explicit: ArgExplicitlyProvided<A>
+): Promise<ArgValues<A>> {
+  if (!hook) {
+    return values
+  }
+  return (await hook({ values, explicit })) ?? values
+}

--- a/packages/gunshi/src/resolver.ts
+++ b/packages/gunshi/src/resolver.ts
@@ -24,5 +24,8 @@ export async function resolveValue<A extends Args>(
   if (!hook) {
     return values
   }
-  return (await hook({ values, explicit })) ?? values
+  // Pass a frozen shallow copy so hook cannot mutate the original values;
+  // the original is preserved as the fallback when the hook returns undefined.
+  const snapshot = Object.freeze({ ...values }) as ArgValues<A>
+  return (await hook({ values: snapshot, explicit })) ?? values
 }

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -239,6 +239,22 @@ export interface CommandEnvironment<G extends GunshiParamsConstraint = DefaultGu
 }
 
 /**
+ * Value resolution sources for the onResolveValue hook.
+ *
+ * @typeParam A - The Args type from command definition
+ */
+export interface ValueResolutionSources<A extends Args = Args> {
+  /**
+   * Parsed argument values, with defaults from schema filled in for unset keys
+   */
+  values: ArgValues<A>
+  /**
+   * Map of which keys were explicitly provided via command line arguments
+   */
+  explicit: ArgExplicitlyProvided<A>
+}
+
+/**
  * CLI options of {@linkcode cli} function.
  *
  * @typeParam G - A type extending {@linkcode GunshiParams} to specify the shape of cli options.
@@ -335,6 +351,19 @@ export interface CliOptions<G extends GunshiParamsConstraint = DefaultGunshiPara
    * @since v0.27.0
    */
   onErrorCommand?: (ctx: Readonly<CommandContext<G>>, error: Error) => Awaitable<void>
+  /**
+   * Hook that runs once after argument parsing and before command execution.
+   *
+   * Receives parsed argv values (with schema defaults filled in) and explicit CLI keys.
+   * The hook is responsible for merging values from any external sources (e.g. config files, env vars).
+   * The returned record becomes the final resolved values for the command context.
+   *
+   * @param sources - Parsed argv values and explicit CLI keys
+   * @returns The final resolved values, or undefined to use parsed argv values as-is
+   */
+  onResolveValue?: (
+    sources: ValueResolutionSources<ExtractArgs<G>>
+  ) => Awaitable<ArgValues<ExtractArgs<G>> | undefined>
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the `onResolveValue` lifecycle hook as discussed in the related issue.

- Add `ValueResolutionSources<A>` interface — contains `values` (parsed argv with schema defaults) and `explicit` (map of keys explicitly provided via CLI)
- Add `onResolveValue` option to `CliOptions` — called once after argument parsing, before command execution, consistent with `onBeforeCommand` / `onAfterCommand` pattern
- Extract `resolveValue` helper into `resolver.ts` with 100% test coverage (statements, branches, functions, lines)

## Design decisions

- Hook is called once (not per-key) with the full sources object
- `values` from `resolveArgs` already has schema defaults filled in by args-tokens, so no separate `defaults` field is needed — `explicit` is sufficient to distinguish CLI-provided values from defaults
- Priority logic is the developer's responsibility inside the hook; gunshi only guarantees the call timing and falls back to original `values` if the hook returns `undefined`
- Hook lives on `CliOptions` only (not `PluginContext`), consistent with other lifecycle hooks — plugins that need this behavior can use `extension` or `decorateCommand`

## Test plan

- [x] `pnpm test:core` — 207 tests pass, no type errors
- [x] `pnpm lint` — all checks pass
- [x] `resolver.ts` coverage — 100% statements / branches / functions / lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable post-parse value-resolution hook; CLI will revalidate and clear required-argument errors when the hook supplies missing values. Public options/types updated to accept this hook.

* **Tests**
  * Added unit and CLI tests covering hook behavior, fallbacks, immutable snapshots, partial explicit flags, sync/async handlers, and revalidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->