### PR TITLE
fix(cli): route validation errors to `onErrorCommand`

### DIFF
--- a/e2e/fixture/advanced/custom-rendering/config.json
+++ b/e2e/fixture/advanced/custom-rendering/config.json
@@ -5,5 +5,5 @@
   ["add-fully-option", "node cli.js --add \"Important meeting\" --priority high --due 2023-12-31"],
   ["list", "node cli.js --list"],
   ["completion", "node cli.js --complete \"Complete the project\""],
-  ["invalid-error", "node cli.js --add"]
+  ["invalid-error", "node cli.js --add || true"]
 ]

--- a/e2e/fixture/plugins/type-system/config.json
+++ b/e2e/fixture/plugins/type-system/config.json
@@ -1,5 +1,5 @@
 [
-  ["entry", "node cli.ts"],
+  ["entry", "node cli.ts || true"],
   ["help", "node cli.ts --help"],
   ["endpoint-users", "API_TOKEN=xxx node cli.ts fetch --endpoint /users"],
   ["endpoint-users-1", "API_TOKEN=xxx node cli.ts fetch --endpoint /users/1"]

--- a/packages/docs/src/guide/advanced/command-hooks.md
+++ b/packages/docs/src/guide/advanced/command-hooks.md
@@ -43,6 +43,9 @@ Gunshi provides three main lifecycle hooks:
 - **`onAfterCommand`**: Executes after successful command completion
 - **`onErrorCommand`**: Executes when a command throws an error
 
+Argument validation failures are also treated as command errors. Gunshi renders the validation
+error message first, then calls `onErrorCommand` and rejects the `cli()` promise.
+
 ## Basic Hook Usage
 
 ### Setting Up Hooks

--- a/packages/docs/src/guide/advanced/command-hooks.md
+++ b/packages/docs/src/guide/advanced/command-hooks.md
@@ -120,6 +120,45 @@ The `CommandContext` parameter is read-only and contains all command metadata, w
 
 With an understanding of how hooks work and their parameters, let's explore how they differ from and interact with plugin decorators.
 
+### Handling Argument Validation Errors
+
+When argument validation fails, Gunshi renders the validation error message before calling
+`onErrorCommand`. You can detect this case with `ctx.validationError`:
+
+```ts
+import { cli, define } from 'gunshi'
+
+const command = define({
+  name: 'deploy',
+  args: {
+    id: {
+      type: 'string',
+      required: true
+    }
+  },
+  run: ctx => {
+    console.log(`Deploying ${ctx.values.id}`)
+  }
+})
+
+let validationFailed = false
+
+try {
+  await cli(process.argv.slice(2), command, {
+    onErrorCommand: (ctx, error) => {
+      if (ctx.validationError === error) {
+        validationFailed = true
+        process.exitCode = 2
+      }
+    }
+  })
+} catch (error) {
+  if (!validationFailed) {
+    throw error
+  }
+}
+```
+
 ## Hooks vs Decorators
 
 Gunshi provides two distinct mechanisms for controlling command execution:

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -959,10 +959,12 @@ test('enum optional argument', async () => {
   )
 
   // failure case
-  await cli(['--foo', 'z'], {
-    args,
-    run: vi.fn<() => void>()
-  })
+  await expect(
+    cli(['--foo', 'z'], {
+      args,
+      run: vi.fn<() => void>()
+    })
+  ).rejects.toBeInstanceOf(AggregateError)
   const stdout = log()
   expect(stdout).toEqual(
     `Optional argument '--foo' should be chosen from 'enum' ["a", "b", "c"] values`
@@ -995,10 +997,12 @@ describe('positional arguments', () => {
     )
 
     // failure case
-    await cli(['value1'], {
-      args,
-      run: vi.fn<() => void>()
-    })
+    await expect(
+      cli(['value1'], {
+        args,
+        run: vi.fn<() => void>()
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
     const stdout = log()
     expect(stdout).toEqual(`Positional argument 'bar' is required`)
   })
@@ -1056,15 +1060,17 @@ describe('positional arguments', () => {
     )
 
     // failure case
-    await cli(
-      ['command2', '-o=1'],
-      {
-        run: vi.fn<() => void>()
-      },
-      {
-        subCommands
-      }
-    )
+    await expect(
+      cli(
+        ['command2', '-o=1'],
+        {
+          run: vi.fn<() => void>()
+        },
+        {
+          subCommands
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
     const stdout = log()
     expect(stdout).toEqual(`Positional argument 'bar' is required`)
   })
@@ -1243,10 +1249,12 @@ describe('custom type arguments', () => {
       }
     } satisfies Args
 
-    await cli(['--port', '80'], {
-      args,
-      run: vi.fn<() => void>()
-    })
+    await expect(
+      cli(['--port', '80'], {
+        args,
+        run: vi.fn<() => void>()
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
 
     const stdout = log()
     expect(stdout).toContain('Invalid port: 80. Must be a number between 1024 and 65535')
@@ -1475,6 +1483,46 @@ describe('command lifecycle hooks', () => {
 
     expect(executionOrder).toEqual(['before', 'command', 'error'])
     expect(capturedError).toBe(testError)
+  })
+
+  test('onErrorCommand hook with validation error', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+    const executionOrder: string[] = []
+    const mockCommand = vi.fn<() => void>()
+    const args = {
+      id: {
+        type: 'string',
+        required: true
+      }
+    } satisfies Args
+
+    let capturedError: Error | undefined
+
+    await expect(
+      cli(
+        [],
+        { args, run: mockCommand },
+        {
+          onBeforeCommand: () => {
+            executionOrder.push('before')
+          },
+          onAfterCommand: () => {
+            executionOrder.push('after')
+          },
+          onErrorCommand: (ctx, error) => {
+            executionOrder.push('error')
+            capturedError = error
+            expect(ctx.validationError).toBe(error)
+          }
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(executionOrder).toEqual(['before', 'error'])
+    expect(mockCommand).not.toHaveBeenCalled()
+    expect(capturedError).toBeInstanceOf(AggregateError)
+    expect(log()).toBe(`Optional argument '--id' is required`)
   })
 
   test('hooks with subcommands', async () => {

--- a/packages/gunshi/src/rendering.test.ts
+++ b/packages/gunshi/src/rendering.test.ts
@@ -152,7 +152,7 @@ describe('Command rendering options', () => {
         }
       })
 
-      await cli([], cmd, { name: 'test-cli' })
+      await expect(cli([], cmd, { name: 'test-cli' })).rejects.toBeInstanceOf(AggregateError)
 
       const stdout = log()
       expect(stdout).toBe('')
@@ -179,7 +179,7 @@ describe('Command rendering options', () => {
         }
       })
 
-      await cli([], cmd, { name: 'test-cli' })
+      await expect(cli([], cmd, { name: 'test-cli' })).rejects.toBeInstanceOf(AggregateError)
 
       const stdout = log()
       expect(stdout).toContain('ERROR: ')

--- a/packages/plugin-global/src/decorator.test.ts
+++ b/packages/plugin-global/src/decorator.test.ts
@@ -81,3 +81,29 @@ test('base runner execution', async () => {
 
   expect(result).toBe('command executed')
 })
+
+test('throws validation error after showing validation errors', async () => {
+  const validationError = new AggregateError([new Error('missing id')], 'validation failed')
+  const showValidationErrors = vi.fn<(error: AggregateError) => string>(() => 'validation failed')
+  const ctx = await createCommandContext({
+    values: {},
+    validationError,
+    extensions: {
+      [pluginId]: {
+        key: Symbol(pluginId),
+        factory: () => ({
+          showVersion: vi.fn<() => string>(() => '1.0.0'),
+          showHeader: vi.fn<() => string | undefined>(() => undefined),
+          showUsage: vi.fn<() => string | undefined>(() => undefined),
+          showValidationErrors
+        })
+      }
+    }
+  })
+  const baseRunner = vi.fn<() => string>(() => 'command executed')
+
+  await expect(decorator(baseRunner)(ctx)).rejects.toBe(validationError)
+
+  expect(showValidationErrors).toHaveBeenCalledWith(validationError)
+  expect(baseRunner).not.toHaveBeenCalled()
+})

--- a/packages/plugin-global/src/decorator.ts
+++ b/packages/plugin-global/src/decorator.ts
@@ -48,7 +48,8 @@ const decorator: CommandDecorator<{
 
   // check for validation errors before executing command
   if (validationError) {
-    return await showValidationErrors(validationError)
+    await showValidationErrors(validationError)
+    throw validationError
   }
 
   // normal command execution


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- Route argument validation failures through the existing command error lifecycle by throwing after rendering validation errors.
- Ensure `onErrorCommand` is invoked for validation failures while command runners and `onAfterCommand` are skipped.
- Update tests and command hooks documentation for the new validation error behavior.


### Linked Issues

resolve #522

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the error-handling sequence for argument validation failures in the command-hooks guide.

* **Bug Fixes**
  * Fixed validation error handling to properly reject promises with error details, ensuring consistent behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->