### PR TITLE
chore!: drop Node.js v20 support, require v22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "devEngines": {
     "runtime": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "runtime": [
       {
         "name": "node",
-        "version": ">=20",
+        "version": ">=22",
         "onFail": "error"
       },
       {

--- a/packages/bone/package.json
+++ b/packages/bone/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/combinators/package.json
+++ b/packages/combinators/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/definition/package.json
+++ b/packages/definition/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/docs/src/guide/introduction/setup.md
+++ b/packages/docs/src/guide/introduction/setup.md
@@ -103,7 +103,7 @@ For more information, refer to the Gunshi API documentation in `node_modules/@gu
 Gunshi requires:
 
 - **JavaScript Runtime**:
-  - **Node.js**: v20 or later
+  - **Node.js**: v22 or later
   - **Deno**: v2 or later
   - **Bun**: v1.1 or later
 - **ES Modules**: `"type": "module"` in `package.json` (if using Node.js and Bun)

--- a/packages/gunshi/package.json
+++ b/packages/gunshi/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin-completion/package.json
+++ b/packages/plugin-completion/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin-dryrun/package.json
+++ b/packages/plugin-dryrun/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin-global/package.json
+++ b/packages/plugin-global/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin-i18n/package.json
+++ b/packages/plugin-i18n/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin-renderer/package.json
+++ b/packages/plugin-renderer/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "files": [


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum Node.js requirement to v22 across all packages and updated installation docs accordingly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazupon/gunshi/pull/548)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->