### PR TITLE
fix(#499): parse arguments for lazy loaded command objects

### DIFF
--- a/e2e/fixture/essentials/lazy-async/dynamic-command/config-help.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/config-help.snap
@@ -8,4 +8,5 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Verbose output
 

--- a/e2e/fixture/essentials/lazy-async/dynamic-command/config.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/config.snap
@@ -1,3 +1,4 @@
 my-cli (my-cli v1.0.0)
 
 Running in normal mode
+Verbose: true

--- a/e2e/fixture/essentials/lazy-async/dynamic-command/debug-config-help.snap
+++ b/e2e/fixture/essentials/lazy-async/dynamic-command/debug-config-help.snap
@@ -8,4 +8,5 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Verbose output (DEBUG mode)
 

--- a/packages/gunshi/src/__snapshots__/cli.test.ts.snap
+++ b/packages/gunshi/src/__snapshots__/cli.test.ts.snap
@@ -504,6 +504,20 @@ OPTIONS:
 "
 `;
 
+exports[`github issues > #499 - lazy command args not parsed > lazy sub-command usage includes argument definitions 1`] = `
+"my-cli (my-cli v1.0.0)
+Say hello
+
+USAGE:
+  my-cli hello <OPTIONS>
+
+OPTIONS:
+  -h, --help             Display this help message
+  -v, --version          Display this version
+  --name [name]          The name of the person to say hello to (default: World)
+"
+`;
+
 exports[`lazy command > command loading > config-command 1`] = `
 "lazy-command-loading (lazy-command-loading v1.0.0)
 Loaded configured command
@@ -514,6 +528,7 @@ USAGE:
 OPTIONS:
   -h, --help             Display this help message
   -v, --version          Display this version
+  --verbose              Enable verbose output (default: false)
 "
 `;
 

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -5,6 +5,7 @@ import i18n from '../../plugin-i18n/src/index.ts'
 import { defineMockLog } from '../test/utils.ts'
 import { cli } from './cli.ts'
 import { define, lazy } from './definition.ts'
+import { generate } from './generator.ts'
 import { plugin } from './plugin/core.ts'
 import { renderValidationErrors } from './renderer.ts'
 
@@ -1688,6 +1689,62 @@ describe('github issues', () => {
     expect(rendered3).toMatchSnapshot('example3')
 
     expect(log()).toMatchSnapshot('console output')
+  })
+
+  describe('#499 - lazy command args not parsed', () => {
+    const mainCommand = define({
+      description: 'My CLI application',
+      run: () => {}
+    })
+
+    const helloLoader = () => {
+      return define({
+        description: 'Say hello',
+        args: {
+          name: {
+            type: 'string',
+            description: 'The name of the person to say hello to',
+            default: 'World'
+          }
+        },
+        run(ctx) {
+          console.log(`Hello ${ctx.values.name}!`)
+        }
+      })
+    }
+
+    const hello = lazy(helloLoader, {
+      name: 'hello',
+      description: 'Say hello'
+    })
+
+    const cliOptions: CliOptions = {
+      name: 'my-cli',
+      version: '1.0.0',
+      subCommands: { hello }
+    }
+
+    test('lazy sub-command uses default argument values', async () => {
+      using spy = vi.spyOn(console, 'log')
+
+      await cli(['hello'], mainCommand, cliOptions)
+
+      expect(spy).toHaveBeenLastCalledWith('Hello World!')
+    })
+
+    test('lazy sub-command uses argument values', async () => {
+      using spy = vi.spyOn(console, 'log')
+
+      await cli(['hello', '--name', 'Gunshi'], mainCommand, cliOptions)
+
+      expect(spy).toHaveBeenLastCalledWith('Hello Gunshi!')
+    })
+
+    test('lazy sub-command usage includes argument definitions', async () => {
+      const usage = await generate('hello', mainCommand, cliOptions)
+
+      expect(usage).toMatchSnapshot()
+    })
   })
 })
 

--- a/playground/essentials/lazy-async/dynamic-command/cli.ts
+++ b/playground/essentials/lazy-async/dynamic-command/cli.ts
@@ -15,7 +15,7 @@ const configLoader = async () => {
     run: ctx => {
       console.log(isDebug ? 'Running in DEBUG mode' : 'Running in normal mode')
       if (ctx.values.verbose) {
-        console.log('Verbose:', ctx.values)
+        console.log('Verbose:', ctx.values.verbose)
       }
     }
   })


### PR DESCRIPTION
close #499 
close #500
Thank @cameronhunter for your contribution

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with lazy-loaded sub-commands where arguments were not parsed correctly. Command resolution now occurs earlier in the parsing process to ensure argument defaults and definitions are properly applied.

* **Tests**
  * Added test coverage for lazy-loaded sub-commands, including handling of default argument values, provided argument values, and generated usage documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazupon/gunshi/pull/554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->