### PR TITLE
feat(plugin-completion): support Bun runtimes

### DIFF
--- a/e2e/bun.spec.ts
+++ b/e2e/bun.spec.ts
@@ -1,6 +1,14 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { expect, test } from 'vitest'
 import { runCommand } from '../scripts/utils.ts'
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll(`'`, `'\\''`)}'`
+}
 
 test('bun', async () => {
   // install dependencies
@@ -11,4 +19,46 @@ test('bun', async () => {
     cwd: path.resolve(import.meta.dirname, '../playground/bun')
   })
   expect(output).include(`Hello, Gunshi with Bun!`)
+})
+
+test('bun source completion', async () => {
+  const fixture = path.resolve(ROOT, 'packages/plugin-completion/examples/basic.node.ts')
+  const command = `bun ${shellQuote(fixture)}`
+  const script = await runCommand(`${command} complete zsh`, {
+    cwd: ROOT
+  })
+  expect(script).include('bun')
+
+  const output = await runCommand(`${command} complete -- --config vite.config`, {
+    cwd: ROOT
+  })
+  expect(output).include('vite.config.ts')
+})
+
+test('bun single binary completion', async () => {
+  const fixture = path.resolve(ROOT, 'packages/plugin-completion/examples/basic.node.ts')
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'gunshi-completion-bun-'))
+  const outfile = path.join(tmpDir, 'gunshi-completion-bun')
+
+  try {
+    await runCommand(
+      `bun build --compile ${shellQuote(fixture)} --outfile ${shellQuote(outfile)}`,
+      {
+        cwd: ROOT,
+        timeout: 60_000
+      }
+    )
+
+    const script = await runCommand(`${shellQuote(outfile)} complete zsh`, {
+      cwd: ROOT
+    })
+    expect(script).include(outfile)
+
+    const output = await runCommand(`${shellQuote(outfile)} complete -- --config vite.config`, {
+      cwd: ROOT
+    })
+    expect(output).include('vite.config.ts')
+  } finally {
+    await rm(tmpDir, { force: true, recursive: true })
+  }
 })

--- a/e2e/bun.spec.ts
+++ b/e2e/bun.spec.ts
@@ -6,6 +6,8 @@ import { runCommand } from '../scripts/utils.ts'
 
 const ROOT = path.resolve(import.meta.dirname, '..')
 
+// runCommand uses node:child_process exec, and E2E CI runs on ubuntu-latest,
+// so these command strings intentionally use POSIX shell quoting.
 function shellQuote(value: string): string {
   return `'${value.replaceAll(`'`, `'\\''`)}'`
 }

--- a/packages/plugin-completion/README.md
+++ b/packages/plugin-completion/README.md
@@ -13,7 +13,7 @@ This completion plugin is powered by [`@bomb.sh/tab`](https://github.com/bombshe
 <!-- eslint-disable markdown/no-missing-label-refs -->
 
 > [!WARNING]
-> This package support Node.js runtime only. Deno and Bun support are coming soon.
+> This package support Node.js and Bun runtime only. Deno support is not available yet.
 
 <!-- eslint-enable markdown/no-missing-label-refs -->
 
@@ -116,20 +116,24 @@ The `complete` command accepts the following shell types:
 
 <!-- eslint-enable markdown/no-missing-label-refs -->
 
+### Runtime Support
+
+The plugin supports completion script generation for Node.js, Bun source execution, and Bun single-file executables.
+
+Runtime detection is intentionally conservative:
+
+- **Bun source execution** replays the current Bun executable, `process.execArgv`, and the source entry. This follows Bun's documented argument vector shape, where the launcher is first and the source file is second. See [Bun's `argv` guide](https://bun.com/guides/process/argv) and [single-file executable docs](https://bun.com/docs/bundler/executables).
+- **Bun single-file executables** call the compiled executable itself. Bun does not currently expose a stable runtime flag that says "this process is a compiled executable", so the plugin uses an internal heuristic based on `process.execPath` and Bun virtual entries. This avoids regenerating a completion script that tries to call the original source file from inside a compiled binary. The heuristic is intentionally private; related Bun compile behavior is discussed in [oven-sh/bun#14676](https://github.com/oven-sh/bun/issues/14676) and [oven-sh/bun#13405](https://github.com/oven-sh/bun/issues/13405).
+
+Deno runtime completion script generation is not supported yet.
+
 ## Shell Completion Setup
 
 This section provides detailed instructions for setting up shell completions in different shells. The setup is a one-time process that enables tab completion for your CLI.
 
 ### Prerequisites
 
-Shell completion requires Node.js runtime. Ensure your CLI is running with Node.js (not Deno or Bun).
-
-<!-- eslint-disable markdown/no-missing-label-refs -->
-
-> [!WARNING]
-> This package support Node.js runtime only. Deno and Bun support are coming soon.
-
-<!-- eslint-enable markdown/no-missing-label-refs -->
+Shell completion requires your CLI command to be executable from the generated completion script.
 
 ### Setup by Shell
 

--- a/packages/plugin-completion/README.md
+++ b/packages/plugin-completion/README.md
@@ -13,7 +13,7 @@ This completion plugin is powered by [`@bomb.sh/tab`](https://github.com/bombshe
 <!-- eslint-disable markdown/no-missing-label-refs -->
 
 > [!WARNING]
-> This package support Node.js and Bun runtime only. Deno support is not available yet.
+> This package supports Node.js and Bun runtimes only. Deno support is not available yet.
 
 <!-- eslint-enable markdown/no-missing-label-refs -->
 
@@ -116,17 +116,6 @@ The `complete` command accepts the following shell types:
 
 <!-- eslint-enable markdown/no-missing-label-refs -->
 
-### Runtime Support
-
-The plugin supports completion script generation for Node.js, Bun source execution, and Bun single-file executables.
-
-Runtime detection is intentionally conservative:
-
-- **Bun source execution** replays the current Bun executable, `process.execArgv`, and the source entry. This follows Bun's documented argument vector shape, where the launcher is first and the source file is second. See [Bun's `argv` guide](https://bun.com/guides/process/argv) and [single-file executable docs](https://bun.com/docs/bundler/executables).
-- **Bun single-file executables** call the compiled executable itself. Bun does not currently expose a stable runtime flag that says "this process is a compiled executable", so the plugin uses an internal heuristic based on `process.execPath` and Bun virtual entries. This avoids regenerating a completion script that tries to call the original source file from inside a compiled binary. The heuristic is intentionally private; related Bun compile behavior is discussed in [oven-sh/bun#14676](https://github.com/oven-sh/bun/issues/14676) and [oven-sh/bun#13405](https://github.com/oven-sh/bun/issues/13405).
-
-Deno runtime completion script generation is not supported yet.
-
 ## Shell Completion Setup
 
 This section provides detailed instructions for setting up shell completions in different shells. The setup is a one-time process that enables tab completion for your CLI.
@@ -134,6 +123,7 @@ This section provides detailed instructions for setting up shell completions in 
 ### Prerequisites
 
 Shell completion requires your CLI command to be executable from the generated completion script.
+The plugin currently supports completion script generation for Node.js, Bun source execution, and Bun single-file executables.
 
 ### Setup by Shell
 

--- a/packages/plugin-completion/docs/functions/default.md
+++ b/packages/plugin-completion/docs/functions/default.md
@@ -7,7 +7,7 @@
 # Function: default()
 
 ```ts
-function default(options): PluginWithoutExtension;
+function default(options?): PluginWithoutExtension;
 ```
 
 completion plugin

--- a/packages/plugin-completion/docs/interfaces/CompletionConfig.md
+++ b/packages/plugin-completion/docs/interfaces/CompletionConfig.md
@@ -12,5 +12,5 @@ Completion configuration, which structure is similar `bombsh/tab`'s `CompletionC
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="args"></a> `args?` | `Record`\<`string`, \{ `handler`: [`CompletionHandler`](../type-aliases/CompletionHandler.md); \}\> | The command arguments for the completion. |
-| <a id="handler"></a> `handler?` | [`CompletionHandler`](../type-aliases/CompletionHandler.md) | The [`handler`](../type-aliases/CompletionHandler.md) for the completion. |
+| <a id="property-args"></a> `args?` | `Record`\<`string`, \{ `handler`: [`CompletionHandler`](../type-aliases/CompletionHandler.md); \}\> | The command arguments for the completion. |
+| <a id="property-handler"></a> `handler?` | [`CompletionHandler`](../type-aliases/CompletionHandler.md) | The [`handler`](../type-aliases/CompletionHandler.md) for the completion. |

--- a/packages/plugin-completion/docs/interfaces/CompletionOptions.md
+++ b/packages/plugin-completion/docs/interfaces/CompletionOptions.md
@@ -12,6 +12,6 @@ Completion plugin options.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="config"></a> `config?` | `object` | The completion configuration |
+| <a id="property-config"></a> `config?` | `object` | The completion configuration |
 | `config.entry?` | [`CompletionConfig`](CompletionConfig.md) | The entry point [`completion configuration`](CompletionConfig.md). |
 | `config.subCommands?` | `Record`\<`string`, [`CompletionConfig`](CompletionConfig.md)\> | The handlers for sub-commands. |

--- a/packages/plugin-completion/docs/interfaces/CompletionParams.md
+++ b/packages/plugin-completion/docs/interfaces/CompletionParams.md
@@ -12,4 +12,4 @@ Parameters for [`the completion handler`](../type-aliases/CompletionHandler.md).
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="locale"></a> `locale?` | `Locale` | The locale to use for i18n. |
+| <a id="property-locale"></a> `locale?` | `Locale` | The locale to use for i18n. |

--- a/packages/plugin-completion/docs/type-aliases/CompletionHandler.md
+++ b/packages/plugin-completion/docs/type-aliases/CompletionHandler.md
@@ -4,7 +4,7 @@
 
 [@gunshi/plugin-completion](../index.md) / CompletionHandler
 
-# Type Alias: CompletionHandler()
+# Type Alias: CompletionHandler
 
 ```ts
 type CompletionHandler = (params) => Completion[];

--- a/packages/plugin-completion/src/utils.test.ts
+++ b/packages/plugin-completion/src/utils.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   detectRuntime,
+  detectRuntimeFromGlobals,
   joinExecParts,
   resolveBunExecParts,
   resolveNodeExecParts,
@@ -27,9 +28,15 @@ function createProcess(overrides: Partial<ProcessLike> = {}): ProcessLike {
 }
 
 describe('detectRuntime', () => {
+  test('detects the current Node.js test runtime', () => {
+    expect(detectRuntime()).toBe('node')
+  })
+})
+
+describe('detectRuntimeFromGlobals', () => {
   test('prioritizes Bun over Deno and Node-compatible process', () => {
     expect(
-      detectRuntime({
+      detectRuntimeFromGlobals({
         Bun: {},
         Deno: {},
         process: createProcess()
@@ -39,7 +46,7 @@ describe('detectRuntime', () => {
 
   test('prioritizes Deno over Node-compatible process', () => {
     expect(
-      detectRuntime({
+      detectRuntimeFromGlobals({
         Deno: {},
         process: createProcess()
       })
@@ -48,7 +55,7 @@ describe('detectRuntime', () => {
 
   test('detects Node from process release name', () => {
     expect(
-      detectRuntime({
+      detectRuntimeFromGlobals({
         process: createProcess()
       })
     ).toBe('node')

--- a/packages/plugin-completion/src/utils.test.ts
+++ b/packages/plugin-completion/src/utils.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { describe, expect, test } from 'vitest'
+import {
+  detectRuntime,
+  joinExecParts,
+  resolveBunExecParts,
+  resolveNodeExecParts,
+  shellQuote
+} from './utils.ts'
+
+import type { ProcessLike } from './utils.ts'
+
+function createProcess(overrides: Partial<ProcessLike> = {}): ProcessLike {
+  return {
+    argv: ['/usr/local/bin/node', './cli.ts'],
+    execArgv: [],
+    execPath: '/usr/local/bin/node',
+    release: {
+      name: 'node'
+    },
+    ...overrides
+  }
+}
+
+describe('detectRuntime', () => {
+  test('prioritizes Bun over Deno and Node-compatible process', () => {
+    expect(
+      detectRuntime({
+        Bun: {},
+        Deno: {},
+        process: createProcess()
+      })
+    ).toBe('bun')
+  })
+
+  test('prioritizes Deno over Node-compatible process', () => {
+    expect(
+      detectRuntime({
+        Deno: {},
+        process: createProcess()
+      })
+    ).toBe('deno')
+  })
+
+  test('detects Node from process release name', () => {
+    expect(
+      detectRuntime({
+        process: createProcess()
+      })
+    ).toBe('node')
+  })
+})
+
+describe('resolveNodeExecParts', () => {
+  test('resolves Node source execution', () => {
+    expect(resolveNodeExecParts(createProcess())).toEqual(['/usr/local/bin/node', './cli.ts'])
+  })
+})
+
+describe('resolveBunExecParts', () => {
+  test('resolves Bun source execution', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['/usr/local/bin/bun', './src/cli.ts'],
+          execPath: '/usr/local/bin/bun'
+        })
+      )
+    ).toEqual(['/usr/local/bin/bun', './src/cli.ts'])
+  })
+
+  test('resolves Bun source execution with execArgv', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['/usr/local/bin/bun', './src/cli.ts'],
+          execArgv: ['--smol'],
+          execPath: '/usr/local/bin/bun'
+        })
+      )
+    ).toEqual(['/usr/local/bin/bun', '--smol', './src/cli.ts'])
+  })
+
+  test('resolves Bun single binary on Unix', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['/tmp/my-cli'],
+          execPath: '/tmp/my-cli'
+        })
+      )
+    ).toEqual(['/tmp/my-cli'])
+  })
+
+  test('resolves Bun single binary on Windows', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['C:\\tools\\my-cli.exe'],
+          execPath: 'C:\\tools\\my-cli.exe'
+        })
+      )
+    ).toEqual(['C:\\tools\\my-cli.exe'])
+  })
+
+  test('resolves Bun Unix virtual compiled entry', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['/usr/local/bin/bun', '/$bunfs/root/main.js'],
+          execPath: '/usr/local/bin/bun'
+        })
+      )
+    ).toEqual(['/usr/local/bin/bun'])
+  })
+
+  test('resolves Bun Windows virtual compiled entry', () => {
+    expect(
+      resolveBunExecParts(
+        createProcess({
+          argv: ['C:\\tools\\bun.exe', 'B:\\~BUN\\root.js'],
+          execPath: 'C:\\tools\\bun.exe'
+        })
+      )
+    ).toEqual(['C:\\tools\\bun.exe'])
+  })
+})
+
+describe('shellQuote', () => {
+  test('escapes spaces and single quotes', () => {
+    expect(shellQuote("/tmp/my cli's/bin")).toBe(`'/tmp/my cli'\\''s/bin'`)
+  })
+
+  test('joins quoted exec parts without extra spaces', () => {
+    expect(joinExecParts(['/tmp/my cli/bin', "--flag=it's", './cli.ts'])).toBe(
+      String.raw`'/tmp/my cli/bin' '--flag=it'\\''s' ./cli.ts`
+    )
+  })
+
+  test('escapes metacharacters for generated double-quoted shell assignment', () => {
+    expect(
+      joinExecParts(['/tmp/$(touch pwn)/my cli', '--loader=`touch pwn`', './"quoted".ts'])
+    ).toBe("'/tmp/\\$(touch pwn)/my cli' '--loader=\\`touch pwn\\`' './\\\"quoted\\\".ts'")
+  })
+
+  test('preserves backslashes through generated double-quoted shell assignment', () => {
+    expect(joinExecParts(['C:\\tools\\my cli.exe'])).toBe("'C:\\\\tools\\\\my cli.exe'")
+  })
+})

--- a/packages/plugin-completion/src/utils.test.ts
+++ b/packages/plugin-completion/src/utils.test.ts
@@ -5,7 +5,6 @@
 
 import { describe, expect, test } from 'vitest'
 import {
-  detectRuntime,
   detectRuntimeFromGlobals,
   joinExecParts,
   resolveBunExecParts,
@@ -26,12 +25,6 @@ function createProcess(overrides: Partial<ProcessLike> = {}): ProcessLike {
     ...overrides
   }
 }
-
-describe('detectRuntime', () => {
-  test('detects the current Node.js test runtime', () => {
-    expect(detectRuntime()).toBe('node')
-  })
-})
 
 describe('detectRuntimeFromGlobals', () => {
   test('prioritizes Bun over Deno and Node-compatible process', () => {

--- a/packages/plugin-completion/src/utils.ts
+++ b/packages/plugin-completion/src/utils.ts
@@ -62,12 +62,21 @@ function getRuntimeGlobals(): RuntimeGlobals {
 }
 
 /**
+ * Detect the active JavaScript runtime.
+ *
+ * @returns The detected runtime name
+ */
+export function detectRuntime(): Runtime {
+  return detectRuntimeFromGlobals(getRuntimeGlobals())
+}
+
+/**
  * Detect the active JavaScript runtime from globals.
  *
  * @param globals - Runtime globals to inspect
  * @returns The detected runtime name
  */
-export function detectRuntime(globals: RuntimeGlobals = getRuntimeGlobals()): Runtime {
+export function detectRuntimeFromGlobals(globals: RuntimeGlobals): Runtime {
   // Bun and Deno expose Node-compatible globals, so runtime-specific markers
   // must be checked before the Node `process.release` fallback.
   if (globals.Bun !== undefined) {
@@ -214,7 +223,7 @@ export function joinExecParts(parts: string[]): string {
  */
 export function quoteExec(): string {
   const globals = getRuntimeGlobals()
-  const runtime = detectRuntime(globals)
+  const runtime = detectRuntime()
 
   switch (runtime) {
     case 'node': {
@@ -227,7 +236,7 @@ export function quoteExec(): string {
       return joinExecParts(resolveBunExecParts(globals.process!))
     }
     default: {
-      throw new Error('Unsupported your javascript runtime for completion script generation.')
+      throw new Error('Unsupported JavaScript runtime for completion script generation.')
     }
   }
 }

--- a/packages/plugin-completion/src/utils.ts
+++ b/packages/plugin-completion/src/utils.ts
@@ -66,7 +66,7 @@ function getRuntimeGlobals(): RuntimeGlobals {
  *
  * @returns The detected runtime name
  */
-export function detectRuntime(): Runtime {
+function detectRuntime(): Runtime {
   return detectRuntimeFromGlobals(getRuntimeGlobals())
 }
 

--- a/packages/plugin-completion/src/utils.ts
+++ b/packages/plugin-completion/src/utils.ts
@@ -3,24 +3,208 @@
  * @license MIT
  */
 
-function detectRuntime(): 'bun' | 'deno' | 'node' | 'unknown' {
-  // @ts-ignore -- NOTE(kazupon): ignore, because `process` will detect ts compile error on `deno check`
-  if (globalThis.process !== undefined && globalThis.process.release?.name === 'node') {
-    return 'node'
+/**
+ * JavaScript runtime name used for executable detection.
+ */
+export type Runtime = 'bun' | 'deno' | 'node' | 'unknown'
+
+/**
+ * Minimal process shape needed to resolve the current executable.
+ */
+export interface ProcessLike {
+  /**
+   * Runtime arguments.
+   */
+  argv: string[]
+  /**
+   * Runtime execution arguments.
+   * Bun compiled executables can embed runtime arguments into this value via
+   * `bun build --compile --compile-exec-argv`.
+   *
+   * @see https://bun.com/docs/bundler/executables#embedding-runtime-arguments
+   */
+  execArgv?: string[]
+  /**
+   * Runtime executable path.
+   */
+  execPath: string
+  /**
+   * Runtime release metadata.
+   */
+  release?: {
+    /**
+     * Runtime release name.
+     */
+    name?: string
   }
-  // @ts-ignore -- NOTE(kazupon): ignore, because development env is node.js
-  if (globalThis.Deno !== undefined) {
+}
+
+/**
+ * Runtime globals used by executable detection.
+ */
+export interface RuntimeGlobals {
+  /**
+   * Bun global marker.
+   */
+  Bun?: unknown
+  /**
+   * Deno global marker.
+   */
+  Deno?: unknown
+  /**
+   * Node-compatible process global.
+   */
+  process?: ProcessLike
+}
+
+function getRuntimeGlobals(): RuntimeGlobals {
+  return globalThis as unknown as RuntimeGlobals
+}
+
+/**
+ * Detect the active JavaScript runtime from globals.
+ *
+ * @param globals - Runtime globals to inspect
+ * @returns The detected runtime name
+ */
+export function detectRuntime(globals: RuntimeGlobals = getRuntimeGlobals()): Runtime {
+  // Bun and Deno expose Node-compatible globals, so runtime-specific markers
+  // must be checked before the Node `process.release` fallback.
+  if (globals.Bun !== undefined) {
+    return 'bun'
+  }
+  if (globals.Deno !== undefined) {
     return 'deno'
   }
-  // @ts-ignore -- NOTE(kazupon): ignore, because development env is node.js
-  if (globalThis.Bun !== undefined) {
-    return 'bun'
+  if (globals.process !== undefined && globals.process.release?.name === 'node') {
+    return 'node'
   }
   return 'unknown'
 }
 
-function quoteIfNeeded(path: string): string {
-  return path.includes(' ') ? `'${path}'` : path
+/**
+ * Quote a shell command part when needed.
+ *
+ * This protects the command part when the generated completion script later
+ * evaluates the assembled command string. Callers that embed the quoted result
+ * into another shell string still need to escape that outer string.
+ *
+ * @param value - The command part to quote
+ * @returns The shell-safe command part
+ */
+export function shellQuote(value: string): string {
+  if (value.length === 0) {
+    return "''"
+  }
+  if (/^[\w%+,./:=@-]+$/.test(value)) {
+    return value
+  }
+  return `'${value.replaceAll(`'`, `'\\''`)}'`
+}
+
+function escapeDoubleQuotedShellString(value: string): string {
+  // @bomb.sh/tab currently embeds the executable command in a double-quoted
+  // `requestComp="..."` assignment before calling `eval`. `shellQuote` protects
+  // token boundaries for the eval step, but `$`, backticks, `"`, and `\` would
+  // still be interpreted while the generated script builds `requestComp`.
+  // https://github.com/bombshell-dev/tab/blob/v0.0.15/src/zsh.ts#L62-L67
+  // https://github.com/bombshell-dev/tab/blob/v0.0.15/src/bash.ts#L45-L53
+  // https://github.com/bombshell-dev/tab/blob/v0.0.15/src/fish.ts#L41-L44
+  return value.replaceAll(/[$`"\\]/g, '\\$&')
+}
+
+function basename(path: string): string {
+  const slash = path.lastIndexOf('/')
+  const backslash = path.lastIndexOf('\\')
+  return path.slice(Math.max(slash, backslash) + 1)
+}
+
+/**
+ * Check if the entry is a Bun virtual entry.
+ *
+ * @param entry - The entry to check
+ * @returns Whether the entry is a Bun virtual entry
+ *
+ * Bun compiled executables may surface internal virtual paths in `process.argv`
+ * instead of the original source entry. These markers are intentionally private
+ * to keep the single-binary check heuristic rather than a public contract.
+ *
+ * @see https://github.com/oven-sh/bun/blob/main/src/standalone_graph/StandaloneModuleGraph.rs#L44-L70
+ * @see https://github.com/oven-sh/bun/blob/main/test/regression/issue/22157.test.ts#L47-L55
+ */
+function isBunVirtualEntry(entry?: string): boolean {
+  return (
+    entry?.startsWith('/$bunfs/') === true ||
+    entry?.startsWith('B:\\~BUN\\') === true ||
+    entry?.startsWith('B:/~BUN/') === true
+  )
+}
+
+/**
+ * Check if the executable is a likely Bun single binary.
+ *
+ * @param execPath - The executable path
+ * @param entry - The entry to check
+ * @returns Whether the executable is a likely Bun single binary
+ *
+ * Bun documents `bun build --compile` as producing a single-file executable,
+ * but it does not expose a stable "compiled executable" runtime flag.
+ * Prefer calling the current executable when `process.execPath` is no longer
+ * the Bun launcher, because the shell completion script needs to re-enter the
+ * compiled CLI rather than the original source file.
+ *
+ * @see https://bun.com/docs/bundler/executables
+ * @see https://github.com/oven-sh/bun/issues/14676
+ */
+function isLikelyBunSingleBinary(execPath: string, entry?: string): boolean {
+  const name = basename(execPath).toLowerCase()
+
+  if (name !== 'bun' && name !== 'bun.exe') {
+    return true
+  }
+
+  return isBunVirtualEntry(entry)
+}
+
+/**
+ * Resolve executable command parts for Node.js source execution.
+ *
+ * @param process - Node-compatible process global
+ * @returns Executable command parts
+ */
+export function resolveNodeExecParts(process: ProcessLike): string[] {
+  const entry = process.argv[1]
+  return [process.execPath, ...(process.execArgv ?? []), ...(entry ? [entry] : [])]
+}
+
+/**
+ * Resolve executable command parts for Bun source and compiled execution.
+ *
+ * @param process - Bun process global
+ * @returns Executable command parts
+ */
+export function resolveBunExecParts(process: ProcessLike): string[] {
+  const entry = process.argv[1]
+
+  if (isLikelyBunSingleBinary(process.execPath, entry)) {
+    return [process.execPath]
+  }
+
+  // Bun source execution follows the runtime argv shape where the launcher is
+  // first and the script entry is second, so replay the launcher, Bun runtime
+  // args, and the source entry.
+  // https://bun.com/guides/process/argv
+  return [process.execPath, ...(process.execArgv ?? []), ...(entry ? [entry] : [])]
+}
+
+/**
+ * Join executable command parts into a shell-safe command string.
+ *
+ * @param parts - Executable command parts
+ * @returns The executable command string
+ */
+export function joinExecParts(parts: string[]): string {
+  return escapeDoubleQuotedShellString(parts.map(shellQuote).join(' '))
 }
 
 /**
@@ -29,24 +213,18 @@ function quoteIfNeeded(path: string): string {
  * @returns The quoted exec command string
  */
 export function quoteExec(): string {
-  const runtime = detectRuntime()
+  const globals = getRuntimeGlobals()
+  const runtime = detectRuntime(globals)
+
   switch (runtime) {
     case 'node': {
-      // @ts-ignore -- NOTE(kazupon): ignore, because `process` will detect ts compile error on `deno check`
-      const execPath = globalThis.process.execPath
-      // @ts-ignore -- NOTE(kazupon): ignore, because `process` will detect ts compile error on `deno check`
-      const processArgs = globalThis.process.argv.slice(1)
-      const quotedExecPath = quoteIfNeeded(execPath)
-      const quotedProcessArgs = processArgs.map(quoteIfNeeded)
-      // @ts-ignore -- NOTE(kazupon): ignore, because `process` will detect ts compile error on `deno check`
-      const quotedProcessExecArgs = globalThis.process.execArgv.map(quoteIfNeeded)
-      return `${quotedExecPath} ${quotedProcessExecArgs.join(' ')} ${quotedProcessArgs[0]}`
+      return joinExecParts(resolveNodeExecParts(globals.process!))
     }
     case 'deno': {
-      throw new Error('deno not implemented yet, welcome contributions :)')
+      throw new Error('Deno runtime is not supported for completion script generation yet.')
     }
     case 'bun': {
-      throw new Error('bun not implemented yet, welcome contributions :)')
+      return joinExecParts(resolveBunExecParts(globals.process!))
     }
     default: {
       throw new Error('Unsupported your javascript runtime for completion script generation.')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Resolve completion script executables for Bun source execution and likely Bun single-file binaries while keeping Deno as an unsupported runtime path.

This PR splits executable resolution into testable helpers, quotes shell command parts consistently, and documents the Bun compile heuristic with upstream references. It also escapes executable commands for the `@bomb.sh/tab` generated shell assignment before `eval` to avoid command substitution while preserving token quoting.

Implementation references:

- Bun source execution argument shape: https://bun.com/guides/process/argv
- Bun single-file executable behavior: https://bun.com/docs/bundler/executables
- Bun embedded runtime arguments: https://bun.com/docs/bundler/executables#embedding-runtime-arguments
- Bun standalone virtual paths: https://github.com/oven-sh/bun/blob/main/src/standalone_graph/StandaloneModuleGraph.rs#L44-L70
- Bun compiled binary `process.argv` behavior: https://github.com/oven-sh/bun/blob/main/test/regression/issue/22157.test.ts#L47-L55
- `@bomb.sh/tab` generated `requestComp` + `eval` patterns:
  - https://github.com/bombshell-dev/tab/blob/v0.0.15/src/zsh.ts#L62-L67
  - https://github.com/bombshell-dev/tab/blob/v0.0.15/src/bash.ts#L45-L53
  - https://github.com/bombshell-dev/tab/blob/v0.0.15/src/fish.ts#L41-L44

Test coverage added:

- Runtime detection priority: Bun, then Deno, then Node.
- Node executable resolution.
- Bun source executable resolution.
- Bun source executable resolution with `process.execArgv`.
- Bun single-file executable resolution on Unix and Windows.
- Bun virtual entry detection for `/$bunfs/`, `B:\~BUN\`, and `B:/~BUN/`.
- Shell quoting for spaces, single quotes, command substitution, backticks, double quotes, and Windows backslashes.
- Bun E2E smoke tests for source execution and `bun build --compile` binaries:
  - `complete zsh`
  - `complete -- --config vite.config`

### Linked Issues

Closes #557

### Additional context

Reviewer focus:

- Bun source execution replays the Bun launcher, runtime args, and source entry.
- Likely Bun single-file executables re-enter the compiled executable itself.
- The Bun virtual path heuristic is intentionally internal and based on current Bun standalone executable paths.
- Deno remains explicitly unsupported for completion script generation in this PR.

Validation:

- `pnpm fix:oxfmt`
- `pnpm test:plugin-completion`
- `pnpm --filter @gunshi/plugin-completion typecheck:deno`
- `pnpm exec vitest run --config vitest.e2e.config.ts e2e/bun.spec.ts`
- `pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bun support for completion script generation (source execution and single-file executables) alongside Node.js; improved runtime detection for multiple JS runtimes.

* **Tests**
  * Added e2e tests for Bun completions (fixture and compiled binary) and unit tests for runtime-detection and command-generation utilities.

* **Documentation**
  * README and docs updated to document Bun support, clarify prerequisites, and refine API/docs anchors and type representations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazupon/gunshi/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
