### PR TITLE
refactor(types): simplify definition helpers

### DIFF
--- a/packages/gunshi/src/context.ts
+++ b/packages/gunshi/src/context.ts
@@ -44,9 +44,26 @@ import type {
  *
  * @internal
  */
-export type ExtractExtensions<E extends Record<string, CommandContextExtension>> = {
+export type ExtractExtensionValues<E extends Record<string, CommandContextExtension>> = {
   [K in keyof E]: E[K] extends CommandContextExtension<infer T> ? T : never
 }
+
+/**
+ * Return type of {@link createCommandContext}
+ *
+ * @internal
+ */
+type CommandContextResult<
+  G extends GunshiParamsConstraint,
+  E extends Record<string, CommandContextExtension>
+> =
+  {} extends ExtractExtensionValues<E>
+    ? Readonly<CommandContext<G>>
+    : Readonly<
+        CommandContext<
+          GunshiParams<{ args: ExtractArgs<G>; extensions: ExtractExtensionValues<E> }>
+        >
+      >
 
 /**
  * Parameters of {@link createCommandContext}
@@ -143,13 +160,7 @@ export async function createCommandContext<
   commandPath = [],
   omitted = false,
   validationError
-}: CommandContextParams<G, V, C, E>): Promise<
-  {} extends ExtractExtensions<E>
-    ? Readonly<CommandContext<G>>
-    : Readonly<
-        CommandContext<GunshiParams<{ args: ExtractArgs<G>; extensions: ExtractExtensions<E> }>>
-      >
-> {
+}: CommandContextParams<G, V, C, E>): Promise<CommandContextResult<G, E>> {
   /**
    * normailize the options schema and values, to avoid prototype pollution
    */
@@ -228,11 +239,7 @@ export async function createCommandContext<
   }
   const ctx = deepFreeze(core, ['extensions'])
 
-  return ctx as {} extends ExtractExtensions<E>
-    ? Readonly<CommandContext<G>>
-    : Readonly<
-        CommandContext<GunshiParams<{ args: ExtractArgs<G>; extensions: ExtractExtensions<E> }>>
-      >
+  return ctx as CommandContextResult<G, E>
 }
 
 function getCommandName<G extends GunshiParams>(cmd: Command<G> | LazyCommand<G>): string {

--- a/packages/gunshi/src/definition.ts
+++ b/packages/gunshi/src/definition.ts
@@ -46,6 +46,7 @@ import type {
   GunshiParams,
   GunshiParamsConstraint,
   LazyCommand,
+  NormalizeToGunshiParams,
   Prettify
 } from './types.ts'
 
@@ -67,24 +68,25 @@ export type {
 export type { CommandContextParams } from './context.ts'
 
 /**
- * Infer command properties excluding for {@link define} function
- *
- * @internal
- */
-type InferCommandProps<G extends GunshiParamsConstraint = DefaultGunshiParams> = Pick<
-  Command<G>,
-  Exclude<keyof Command<G>, keyof Command<G>>
->
-
-/**
  * The result type of the {@link define} function
  *
  * @internal
  */
 type CommandDefinitionResult<
   G extends GunshiParamsConstraint = DefaultGunshiParams,
-  C extends Command<G> = Command<G>
+  C = {}
 > = Prettify<Pick<C, keyof C> & Partial<Pick<Command<G>, Exclude<keyof Command<G>, keyof C>>>>
+
+/**
+ * The command definition accepted by {@link define} helpers.
+ *
+ * @internal
+ */
+type CommandDefinition<
+  A extends Args,
+  E extends ExtendContext,
+  C extends Partial<Command<{ args: A; extensions: E }>>
+> = C & Command<{ args: A; extensions: E }>
 
 /**
  * Define a {@link Command | command}.
@@ -119,10 +121,8 @@ type CommandDefinitionResult<
 export function define<
   G extends GunshiParamsConstraint = DefaultGunshiParams,
   A extends Args = ExtractArgs<G>,
-  C extends InferCommandProps<G> = InferCommandProps<G>
->(
-  definition: C & Command<{ args: A; extensions: ExtractExtensions<G> }>
-): CommandDefinitionResult<G, C>
+  C extends Partial<Command<{ args: A; extensions: ExtractExtensions<G> }>> = {}
+>(definition: CommandDefinition<A, ExtractExtensions<G>, C>): CommandDefinitionResult<G, C>
 
 /**
  * Define a {@link Command | command}.
@@ -147,7 +147,7 @@ type DefineWithTypesReturn<DefaultExtensions extends ExtendContext, DefaultArgs 
   A extends DefaultArgs = DefaultArgs,
   C extends Partial<Command<{ args: A; extensions: DefaultExtensions }>> = {}
 >(
-  definition: C & Command<{ args: A; extensions: DefaultExtensions }>
+  definition: CommandDefinition<A, DefaultExtensions, C>
 ) => CommandDefinitionResult<{ args: A; extensions: DefaultExtensions }, C>
 
 /**
@@ -191,7 +191,7 @@ export function defineWithTypes<G extends GunshiParamsConstraint>(): DefineWithT
     A extends DefaultArgs = DefaultArgs,
     C extends Partial<Command<{ args: A; extensions: DefaultExtensions }>> = {}
   >(
-    definition: C & Command<{ args: A; extensions: DefaultExtensions }>
+    definition: CommandDefinition<A, DefaultExtensions, C>
   ): CommandDefinitionResult<{ args: A; extensions: DefaultExtensions }, C> => {
     return define(definition) as CommandDefinitionResult<
       { args: A; extensions: DefaultExtensions },
@@ -299,24 +299,6 @@ export function lazy<G extends GunshiParamsConstraint = DefaultGunshiParams>(
 }
 
 /**
- * Normalize G to a full GunshiParams type
- *
- * @typeParam G - A {@link GunshiParamsConstraint} type
- *
- * @internal
- */
-type NormalizeGunshiParams<G extends GunshiParamsConstraint> =
-  G extends GunshiParams<any>
-    ? G
-    : G extends { args: infer A; extensions: infer E }
-      ? { args: A; extensions: E }
-      : G extends { args: infer A }
-        ? { args: A; extensions: {} }
-        : G extends { extensions: infer E }
-          ? { args: Args; extensions: E }
-          : DefaultGunshiParams
-
-/**
  * Return type for lazyWithTypes
  *
  * @typeParam FullG - The normalized {@link GunshiParams} type
@@ -365,10 +347,10 @@ type LazyWithTypesReturn<FullG extends GunshiParamsConstraint> = <
  * @since v0.27.0
  */
 export function lazyWithTypes<G extends GunshiParamsConstraint>(): LazyWithTypesReturn<
-  NormalizeGunshiParams<G>
+  NormalizeToGunshiParams<G>
 > {
   // Helper type to normalize G to a full GunshiParams type
-  type FullGunshiParams = NormalizeGunshiParams<G>
+  type FullGunshiParams = NormalizeToGunshiParams<G>
 
   return <D extends Partial<Command<FullGunshiParams>> = {}>(
     loader: CommandLoader<FullGunshiParams>,

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -59,6 +59,7 @@ export type {
   GunshiParams,
   GunshiParamsConstraint,
   LazyCommand,
+  MergeGunshiExtensions,
   NormalizeToGunshiParams,
   Prettify,
   RendererDecorator,

--- a/packages/gunshi/src/plugin/context.ts
+++ b/packages/gunshi/src/plugin/context.ts
@@ -11,23 +11,12 @@ import type {
   CommandContext,
   CommandDecorator,
   DefaultGunshiParams,
-  ExtractArgs,
-  ExtractExtensions,
   GunshiParamsConstraint,
   LazyCommand,
+  MergeGunshiExtensions,
   RendererDecorator,
   ValidationErrorsDecorator
 } from '../types.ts'
-
-/**
- * Type helper to create GunshiParams from extracted args and extensions
- *
- * @internal
- */
-type ExtractedParams<G extends GunshiParamsConstraint, L extends Record<string, unknown> = {}> = {
-  args: ExtractArgs<G>
-  extensions: ExtractExtensions<G> & L
-}
 
 /**
  * Gunshi plugin context interface.
@@ -84,8 +73,8 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
    */
   decorateHeaderRenderer<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
     decorator: (
-      baseRenderer: (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Promise<string>,
-      ctx: Readonly<CommandContext<ExtractedParams<G, L>>>
+      baseRenderer: (ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>) => Promise<string>,
+      ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
     ) => Promise<string>
   ): void
 
@@ -98,8 +87,8 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
    */
   decorateUsageRenderer<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
     decorator: (
-      baseRenderer: (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Promise<string>,
-      ctx: Readonly<CommandContext<ExtractedParams<G, L>>>
+      baseRenderer: (ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>) => Promise<string>,
+      ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
     ) => Promise<string>
   ): void
 
@@ -115,10 +104,10 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
   >(
     decorator: (
       baseRenderer: (
-        ctx: Readonly<CommandContext<ExtractedParams<G, L>>>,
+        ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>,
         error: AggregateError
       ) => Promise<string>,
-      ctx: Readonly<CommandContext<ExtractedParams<G, L>>>,
+      ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>,
       error: AggregateError
     ) => Promise<string>
   ): void
@@ -134,8 +123,10 @@ export interface PluginContext<G extends GunshiParamsConstraint = DefaultGunshiP
    */
   decorateCommand<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
     decorator: (
-      baseRunner: (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Awaitable<void | string>
-    ) => (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Awaitable<void | string>
+      baseRunner: (
+        ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
+      ) => Awaitable<void | string>
+    ) => (ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>) => Awaitable<void | string>
   ): void
 }
 
@@ -199,8 +190,10 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
 
     decorateHeaderRenderer<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
       decorator: (
-        baseRenderer: (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Promise<string>,
-        ctx: Readonly<CommandContext<ExtractedParams<G, L>>>
+        baseRenderer: (
+          ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
+        ) => Promise<string>,
+        ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
       ) => Promise<string>
     ): void {
       decorators.addHeaderDecorator(decorator as unknown as RendererDecorator<string, G>)
@@ -208,8 +201,10 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
 
     decorateUsageRenderer<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
       decorator: (
-        baseRenderer: (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Promise<string>,
-        ctx: Readonly<CommandContext<ExtractedParams<G, L>>>
+        baseRenderer: (
+          ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
+        ) => Promise<string>,
+        ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
       ) => Promise<string>
     ): void {
       decorators.addUsageDecorator(decorator as unknown as RendererDecorator<string, G>)
@@ -220,10 +215,10 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
     >(
       decorator: (
         baseRenderer: (
-          ctx: Readonly<CommandContext<ExtractedParams<G, L>>>,
+          ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>,
           error: AggregateError
         ) => Promise<string>,
-        ctx: Readonly<CommandContext<ExtractedParams<G, L>>>,
+        ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>,
         error: AggregateError
       ) => Promise<string>
     ): void {
@@ -233,9 +228,9 @@ export function createPluginContext<G extends GunshiParamsConstraint = DefaultGu
     decorateCommand<L extends Record<string, unknown> = DefaultGunshiParams['extensions']>(
       decorator: (
         baseRunner: (
-          ctx: Readonly<CommandContext<ExtractedParams<G, L>>>
+          ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>
         ) => Awaitable<void | string>
-      ) => (ctx: Readonly<CommandContext<ExtractedParams<G, L>>>) => Awaitable<void | string>
+      ) => (ctx: Readonly<CommandContext<MergeGunshiExtensions<G, L>>>) => Awaitable<void | string>
     ): void {
       decorators.addCommandDecorator(decorator as unknown as CommandDecorator<G>)
     }

--- a/packages/gunshi/src/plugin/core.ts
+++ b/packages/gunshi/src/plugin/core.ts
@@ -148,6 +148,56 @@ type MergeExtension<
   : ResolvedDepExt
 
 /**
+ * Extensions resolved from the declared plugin dependencies.
+ *
+ * @internal
+ */
+type DependencyExtensions<
+  Deps extends ReadonlyArray<PluginDependency | string>,
+  Context extends ExtendContext
+> = InferDependencyExtensions<Deps, Context>
+
+/**
+ * Gunshi params available while a plugin extension resolves its dependencies.
+ *
+ * @internal
+ */
+type DependencyParams<
+  Deps extends ReadonlyArray<PluginDependency | string>,
+  Context extends ExtendContext
+> = GunshiParams<{
+  args: Args
+  extensions: DependencyExtensions<Deps, Context>
+}>
+
+/**
+ * Extensions available after applying the current plugin extension.
+ *
+ * @internal
+ */
+type MergedPluginExtensions<
+  Id extends string,
+  Deps extends ReadonlyArray<PluginDependency | string>,
+  Context extends ExtendContext,
+  Ext extends ExtendContext
+> = MergeExtension<Id, DependencyExtensions<Deps, Context>, Ext>
+
+/**
+ * Gunshi params available after applying the current plugin extension.
+ *
+ * @internal
+ */
+type MergedPluginParams<
+  Id extends string,
+  Deps extends ReadonlyArray<PluginDependency | string>,
+  Context extends ExtendContext,
+  Ext extends ExtendContext
+> = GunshiParams<{
+  args: Args
+  extensions: MergedPluginExtensions<Id, Deps, Context, Ext>
+}>
+
+/**
  * Plugin definition options
  *
  * @since v0.27.0
@@ -157,19 +207,14 @@ export interface PluginOptions<
   Id extends string = string, // for plugin id
   Deps extends ReadonlyArray<PluginDependency | string> = (PluginDependency | string)[], // for plugin dependencies
   Ext extends Record<string, unknown> = {}, // for plugin extension type
-  ResolvedDepExt extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: InferDependencyExtensions<Deps, DepExt>
-  }>,
+  ResolvedDepExt extends GunshiParams = DependencyParams<Deps, DepExt>,
   PluginExt extends PluginExtension<Ext, ResolvedDepExt> = PluginExtension<Ext, ResolvedDepExt>,
-  MergedExt extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: MergeExtension<
-      Id,
-      InferDependencyExtensions<Deps, DepExt>,
-      Awaited<ReturnType<PluginExt>>
-    >
-  }>
+  MergedExt extends GunshiParams = MergedPluginParams<
+    Id,
+    Deps,
+    DepExt,
+    Awaited<ReturnType<PluginExt>>
+  >
 > {
   /**
    * Plugin unique identifier
@@ -287,7 +332,7 @@ export function plugin<
   Extension extends {} = {}, // for plugin extension type
   ResolvedDepExtensions extends GunshiParams = GunshiParams<{
     args: Args
-    extensions: InferDependencyExtensions<Deps, Context>
+    extensions: DependencyExtensions<Deps, Context>
   }>,
   PluginExt extends PluginExtension<Extension, DefaultGunshiParams> = PluginExtension<
     Extension,
@@ -295,11 +340,7 @@ export function plugin<
   >,
   MergedExtensions extends GunshiParams = GunshiParams<{
     args: Args
-    extensions: MergeExtension<
-      Id,
-      InferDependencyExtensions<Deps, Context>,
-      Awaited<ReturnType<PluginExt>>
-    >
+    extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
   }>
 >(options: {
   id: Id
@@ -310,11 +351,7 @@ export function plugin<
       PluginContext<
         GunshiParams<{
           args: Args
-          extensions: MergeExtension<
-            Id,
-            InferDependencyExtensions<Deps, Context>,
-            Awaited<ReturnType<PluginExt>>
-          >
+          extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
         }>
       >
     >
@@ -343,7 +380,7 @@ export function plugin<
   Extension extends Record<string, unknown> = {}, // for plugin extension type
   ResolvedDepExtensions extends GunshiParams = GunshiParams<{
     args: Args
-    extensions: InferDependencyExtensions<Deps, Context>
+    extensions: DependencyExtensions<Deps, Context>
   }>,
   PluginExt extends PluginExtension<Extension, DefaultGunshiParams> = PluginExtension<
     Extension,
@@ -351,11 +388,7 @@ export function plugin<
   >,
   MergedExtensions extends GunshiParams = GunshiParams<{
     args: Args
-    extensions: MergeExtension<
-      Id,
-      InferDependencyExtensions<Deps, Context>,
-      Awaited<ReturnType<PluginExt>>
-    >
+    extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
   }>
 >(options: {
   id: Id
@@ -366,11 +399,7 @@ export function plugin<
       PluginContext<
         GunshiParams<{
           args: Args
-          extensions: MergeExtension<
-            Id,
-            InferDependencyExtensions<Deps, Context>,
-            Awaited<ReturnType<PluginExt>>
-          >
+          extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
         }>
       >
     >

--- a/packages/gunshi/src/plugin/core.ts
+++ b/packages/gunshi/src/plugin/core.ts
@@ -330,30 +330,24 @@ export function plugin<
   Id extends string = string, // for plugin id
   Deps extends ReadonlyArray<PluginDependency | string> = [], // for plugin dependencies
   Extension extends {} = {}, // for plugin extension type
-  ResolvedDepExtensions extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: DependencyExtensions<Deps, Context>
-  }>,
+  ResolvedDepExtensions extends GunshiParams = DependencyParams<Deps, Context>,
   PluginExt extends PluginExtension<Extension, DefaultGunshiParams> = PluginExtension<
     Extension,
     ResolvedDepExtensions
   >,
-  MergedExtensions extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
-  }>
+  MergedExtensions extends GunshiParams = MergedPluginParams<
+    Id,
+    Deps,
+    Context,
+    Awaited<ReturnType<PluginExt>>
+  >
 >(options: {
   id: Id
   name?: string
   dependencies?: Deps
   setup?: (
     ctx: Readonly<
-      PluginContext<
-        GunshiParams<{
-          args: Args
-          extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
-        }>
-      >
+      PluginContext<MergedPluginParams<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>>
     >
   ) => Awaitable<void>
   extension: PluginExt
@@ -378,30 +372,24 @@ export function plugin<
   Id extends string = string, // for plugin id
   Deps extends ReadonlyArray<PluginDependency | string> = [], // for plugin dependencies
   Extension extends Record<string, unknown> = {}, // for plugin extension type
-  ResolvedDepExtensions extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: DependencyExtensions<Deps, Context>
-  }>,
+  ResolvedDepExtensions extends GunshiParams = DependencyParams<Deps, Context>,
   PluginExt extends PluginExtension<Extension, DefaultGunshiParams> = PluginExtension<
     Extension,
     ResolvedDepExtensions
   >,
-  MergedExtensions extends GunshiParams = GunshiParams<{
-    args: Args
-    extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
-  }>
+  MergedExtensions extends GunshiParams = MergedPluginParams<
+    Id,
+    Deps,
+    Context,
+    Awaited<ReturnType<PluginExt>>
+  >
 >(options: {
   id: Id
   name?: string
   dependencies?: Deps
   setup?: (
     ctx: Readonly<
-      PluginContext<
-        GunshiParams<{
-          args: Args
-          extensions: MergedPluginExtensions<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>
-        }>
-      >
+      PluginContext<MergedPluginParams<Id, Deps, Context, Awaited<ReturnType<PluginExt>>>>
     >
   ) => Awaitable<void>
   onExtension?: OnPluginExtension<MergedExtensions>

--- a/packages/gunshi/src/type.test-d.ts
+++ b/packages/gunshi/src/type.test-d.ts
@@ -5,6 +5,7 @@ import type {
   CommandContext,
   DefaultGunshiParams,
   GunshiParams,
+  MergeGunshiExtensions,
   NormalizeToGunshiParams,
   RenderingOptions
 } from './types.ts'
@@ -72,6 +73,17 @@ test('NormalizeToGunshiParams', () => {
   expectTypeOf<
     NormalizeToGunshiParams<{ args: typeof _args1; extensions: { foo: Extension2 } }>
   >().toEqualTypeOf<GunshiParams<{ args: typeof _args1; extensions: { foo: Extension2 } }>>()
+})
+
+test('MergeGunshiExtensions', () => {
+  expectTypeOf<
+    MergeGunshiExtensions<
+      GunshiParams<{ args: typeof _args1; extensions: { foo: Extension1 } }>,
+      { bar: Extension2 }
+    >
+  >().toEqualTypeOf<
+    GunshiParams<{ args: typeof _args1; extensions: { foo: Extension1 } & { bar: Extension2 } }>
+  >()
 })
 
 test('CommandContext extensions', () => {

--- a/packages/gunshi/src/type.test-d.ts
+++ b/packages/gunshi/src/type.test-d.ts
@@ -5,6 +5,7 @@ import type {
   CommandContext,
   DefaultGunshiParams,
   GunshiParams,
+  NormalizeToGunshiParams,
   RenderingOptions
 } from './types.ts'
 
@@ -57,6 +58,20 @@ test('DefaultGunshiParams', () => {
     args: typeof _args1
     extensions: { foo: Extension1 }
   }>()
+})
+
+test('NormalizeToGunshiParams', () => {
+  expectTypeOf<NormalizeToGunshiParams<{ args: typeof _args1 }>>().toEqualTypeOf<
+    GunshiParams<{ args: typeof _args1; extensions: {} }>
+  >()
+
+  expectTypeOf<NormalizeToGunshiParams<{ extensions: { foo: Extension1 } }>>().toEqualTypeOf<
+    GunshiParams<{ args: Args; extensions: { foo: Extension1 } }>
+  >()
+
+  expectTypeOf<
+    NormalizeToGunshiParams<{ args: typeof _args1; extensions: { foo: Extension2 } }>
+  >().toEqualTypeOf<GunshiParams<{ args: typeof _args1; extensions: { foo: Extension2 } }>>()
 })
 
 test('CommandContext extensions', () => {

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -470,7 +470,7 @@ export interface CommandContext<G extends GunshiParamsConstraint = DefaultGunshi
 }
 
 /**
- * CommandContextCore type (base type without extensions)
+ * Readonly command context available to a command context extension factory.
  *
  * @typeParam G - A type extending {@linkcode GunshiParams} to specify the shape of command context.
  *

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -140,7 +140,13 @@ export type MergeGunshiExtensions<
   G extends GunshiParamsConstraint,
   E extends ExtendContext
 > = GunshiParams<{
+  /**
+   * Command argument definitions.
+   */
   args: ExtractArgs<G>
+  /**
+   * Merged command context extensions.
+   */
   extensions: ExtractExtensions<G> & E
 }>
 

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -132,6 +132,19 @@ export type NormalizeToGunshiParams<G> =
           : DefaultGunshiParams
 
 /**
+ * Type helper to merge command context extensions into G
+ *
+ * @internal
+ */
+export type MergeGunshiExtensions<
+  G extends GunshiParamsConstraint,
+  E extends ExtendContext
+> = GunshiParams<{
+  args: ExtractArgs<G>
+  extensions: ExtractExtensions<G> & E
+}>
+
+/**
  * Command environment.
  *
  * @typeParam G - A type extending {@linkcode GunshiParams} to specify the shape of command environments.

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -123,9 +123,13 @@ export type ExtractExtensions<G> =
 export type NormalizeToGunshiParams<G> =
   G extends GunshiParams<any>
     ? G
-    : G extends { extensions: ExtendContext }
-      ? GunshiParams<{ args: Args; extensions: G['extensions'] }>
-      : DefaultGunshiParams
+    : G extends { args: infer A extends Args; extensions: infer E extends ExtendContext }
+      ? GunshiParams<{ args: A; extensions: E }>
+      : G extends { args: infer A extends Args }
+        ? GunshiParams<{ args: A; extensions: {} }>
+        : G extends { extensions: infer E extends ExtendContext }
+          ? GunshiParams<{ args: Args; extensions: E }>
+          : DefaultGunshiParams
 
 /**
  * Command environment.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined TypeScript typings for command definitions, lazy commands, plugins, and plugin decorators to improve type inference and IDE autocomplete.
  * Renamed and clarified the extension-extraction utility and adjusted command-context return typing for more consistent consumer types.
  * Reworked internal normalization approach for parameter/extension shapes.

* **Exports**
  * Re-exported the merge-extensions utility for consumer use.

* **Tests**
  * Added type-level tests validating parameter normalization and extension merging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazupon/gunshi/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->