### PR TITLE
fix(definition): infer lazy args from inline definitions

### DIFF
--- a/packages/gunshi/src/definition.test-d.ts
+++ b/packages/gunshi/src/definition.test-d.ts
@@ -63,8 +63,9 @@ describe('define', () => {
         expectTypeOf(ctx.values.count).toEqualTypeOf<number | undefined>()
         expectTypeOf(ctx.values.verbose).toEqualTypeOf<boolean>()
         expectTypeOf(ctx.extensions[loggerPluginId]).toEqualTypeOf<LoggerExtension>()
-        // @ts-expect-error unknown plugin extension should not be available
-        ctx.extensions.missing
+        expectTypeOf(ctx.extensions)
+          // @ts-expect-error unknown plugin extension should not be available
+          .toHaveProperty('missing')
       }
     })
   })
@@ -80,8 +81,9 @@ describe('defineWithTypes', () => {
         expectTypeOf(ctx.values.count).toEqualTypeOf<number | undefined>()
         expectTypeOf(ctx.values.verbose).toEqualTypeOf<boolean>()
         expectTypeOf(ctx.extensions[loggerPluginId]).toEqualTypeOf<LoggerExtension>()
-        // @ts-expect-error unknown plugin extension should not be available
-        ctx.extensions.missing
+        expectTypeOf(ctx.extensions)
+          // @ts-expect-error unknown plugin extension should not be available
+          .toHaveProperty('missing')
       }
     })
 
@@ -116,6 +118,41 @@ describe('defineWithTypes', () => {
 })
 
 describe('lazy', () => {
+  test('infers loader context from inline definition without explicit extensions generic (Issue #582)', () => {
+    lazy(
+      () => {
+        return ({ values }) => {
+          const test = values.test
+          expectTypeOf(test).toEqualTypeOf<boolean | undefined>()
+        }
+      },
+      {
+        name: 'main',
+        args: {
+          test: {
+            type: 'boolean'
+          }
+        }
+      }
+    )
+  })
+
+  test('infers standard arg value types from inline definition', () => {
+    lazy(
+      () => {
+        return ({ values }) => {
+          expectTypeOf(values.input).toEqualTypeOf<string>()
+          expectTypeOf(values.count).toEqualTypeOf<number | undefined>()
+          expectTypeOf(values.verbose).toEqualTypeOf<boolean>()
+        }
+      },
+      {
+        name: 'deploy',
+        args: commandArgs
+      }
+    )
+  })
+
   test('infers loader context from CommandRunner annotation', () => {
     const lazyCommand = lazy((): CommandRunner<{ args: typeof commandArgs; extensions: {} }> => {
       return ctx => {
@@ -127,6 +164,19 @@ describe('lazy', () => {
     })
 
     expectTypeOf(lazyCommand.commandName).toEqualTypeOf<string | undefined>()
+  })
+
+  test('preserves inline definition metadata without args', () => {
+    const lazyCommand = lazy(
+      () => {
+        return () => {}
+      },
+      {
+        name: 'lazy'
+      }
+    )
+
+    expectTypeOf(lazyCommand.commandName).toEqualTypeOf<string>()
   })
 
   test('preserves inline definition metadata', () => {

--- a/packages/gunshi/src/definition.ts
+++ b/packages/gunshi/src/definition.ts
@@ -43,7 +43,6 @@ import type {
   ExtendContext,
   ExtractArgs,
   ExtractExtensions,
-  GunshiParams,
   GunshiParamsConstraint,
   LazyCommand,
   NormalizeToGunshiParams,
@@ -153,7 +152,7 @@ type DefineWithTypesReturn<DefaultExtensions extends ExtendContext, DefaultArgs 
 /**
  * Define a {@link Command | command} with types
  *
- * This helper function allows specifying the type parameter of {@link GunshiParams}
+ * This helper function allows specifying the type parameter of {@link GunshiParamsConstraint}
  * while inferring the {@link Args} type, {@link ExtendContext} type from the definition.
  *
  * @example
@@ -173,7 +172,7 @@ type DefineWithTypesReturn<DefaultExtensions extends ExtendContext, DefaultArgs 
  * })
  * ```
  *
- * @typeParam G - A {@link GunshiParams} type
+ * @typeParam G - A {@link GunshiParamsConstraint} type
  *
  * @returns A function that takes a command definition via {@link define}
  *
@@ -246,7 +245,23 @@ export function lazy<A extends Args>(
  * }, testDefinition)
  * ```
  *
- * @typeParam A - An {@link Args} type
+ * @typeParam D - A partial {@link Command} definition type with required `args`
+ *
+ * @param loader - A {@link CommandLoader | command loader} function that returns a command definition
+ * @param definition - A {@link Command | command} definition
+ * @returns A {@link LazyCommand | lazy command} that can be executed later
+ */
+export function lazy<
+  D extends { args: Args } & Partial<Command<{ args: D['args']; extensions: {} }>>
+>(
+  loader: CommandLoader<{ args: D['args']; extensions: {} }>,
+  definition: D
+): LazyCommand<{ args: D['args']; extensions: {} }, D>
+
+/**
+ * Define a {@link LazyCommand | lazy command} with explicit Gunshi parameters and optional definition.
+ *
+ * @typeParam G - A {@link GunshiParamsConstraint}
  * @typeParam D - A partial {@link Command} definition type
  *
  * @param loader - A {@link CommandLoader | command loader} function that returns a command definition
@@ -255,14 +270,8 @@ export function lazy<A extends Args>(
  */
 export function lazy<
   G extends GunshiParamsConstraint = DefaultGunshiParams,
-  A extends ExtractArgs<G> = ExtractArgs<G>,
-  D extends Partial<Command<{ args: A; extensions: {} }>> = Partial<
-    Command<{ args: A; extensions: {} }>
-  >
->(
-  loader: CommandLoader<{ args: A; extensions: {} }>,
-  definition: D
-): LazyCommand<{ args: A; extensions: {} }, D>
+  D extends Partial<Command<G>> = Partial<Command<G>>
+>(loader: CommandLoader<G>, definition?: D): LazyCommand<G, D>
 
 /**
  * Define a {@link LazyCommand | lazy command} with or without definition.
@@ -301,7 +310,7 @@ export function lazy<G extends GunshiParamsConstraint = DefaultGunshiParams>(
 /**
  * Return type for lazyWithTypes
  *
- * @typeParam FullG - The normalized {@link GunshiParams} type
+ * @typeParam FullG - The normalized {@link GunshiParamsConstraint} type
  *
  * @internal
  */
@@ -315,7 +324,7 @@ type LazyWithTypesReturn<FullG extends GunshiParamsConstraint> = <
 /**
  * Define a {@link LazyCommand | lazy command} with specific type parameters.
  *
- * This helper function allows specifying the type parameter of {@link GunshiParams}
+ * This helper function allows specifying the type parameter of {@link GunshiParamsConstraint}
  * while inferring the {@link Args} type, {@link ExtendContext} type from the definition.
  *
  * @example
@@ -340,7 +349,7 @@ type LazyWithTypesReturn<FullG extends GunshiParamsConstraint> = <
  * )
  * ```
  *
- * @typeParam G - A {@link GunshiParams} type
+ * @typeParam G - A {@link GunshiParamsConstraint} type
  *
  * @returns A function that takes a lazy command definition via {@link lazy}
  *


### PR DESCRIPTION
## Summary

Fixes lazy command inference so inline definitions with args feed their schema into the loader context.

This addresses Issue #582: `lazy(() => ..., { args })` no longer widens `ctx.values.foo` to the default string/number/boolean union.

The new overload derives args from the provided definition while preserving explicit generic usage and args-less fallback behavior.

Type tests cover the StackBlitz reproduction plus required, optional, and defaulted arg values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced type inference for lazy-loaded commands, enabling better type inference from inline definitions without explicit generic type parameters
  * Improved type safety validation for command extension configurations with stricter property checking
  * Made definition parameters optional for lazy loaders while maintaining command metadata type preservation

* **Tests**
  * Expanded test coverage for edge cases in type inference and definition handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->