### PR TITLE
feat: localize args validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ importmap.json
 .todo.md
 .notes/**
 .slides/**
+.plans/**

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -1060,6 +1060,149 @@ test('enum optional argument', async () => {
   )
 })
 
+describe('args validation i18n', () => {
+  test('translates required option', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        [],
+        {
+          args: {
+            id: {
+              type: 'string',
+              required: true
+            }
+          },
+          run: vi.fn<() => void>()
+        },
+        {
+          plugins: [
+            i18n({
+              locale: 'ja-JP',
+              builtinResources: {
+                'ja-JP': {
+                  'err:arg:required-option': '必須オプション: {$displayName}'
+                }
+              }
+            })
+          ]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toEqual("必須オプション: '--id'")
+  })
+
+  test('translates required positional', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        [],
+        {
+          args: {
+            file: {
+              type: 'positional'
+            }
+          },
+          run: vi.fn<() => void>()
+        },
+        {
+          plugins: [
+            i18n({
+              locale: 'ja-JP',
+              builtinResources: {
+                'ja-JP': {
+                  'err:arg:required-positional': '必須位置引数: {$name}'
+                }
+              }
+            })
+          ]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toEqual('必須位置引数: file')
+  })
+
+  test('translates invalid type and invalid choice', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        ['--count', 'invalid', '--level', 'trace'],
+        {
+          args: {
+            count: {
+              type: 'number'
+            },
+            level: {
+              type: 'enum',
+              choices: ['debug', 'info']
+            }
+          },
+          run: vi.fn<() => void>()
+        },
+        {
+          plugins: [
+            i18n({
+              locale: 'ja-JP',
+              builtinResources: {
+                'ja-JP': {
+                  'err:arg:invalid-type': '型エラー: {$displayName}',
+                  'err:arg:invalid-choice': '選択エラー: {$displayName}'
+                }
+              }
+            })
+          ]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toEqual(["型エラー: '--count'", "選択エラー: '--level'"].join('\n'))
+  })
+
+  test('translates custom parse wrapper', async () => {
+    const utils = await import('./utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        ['--port', '80'],
+        {
+          args: {
+            port: {
+              type: 'custom',
+              parse: () => {
+                throw new Error('Invalid port')
+              }
+            }
+          },
+          run: vi.fn<() => void>()
+        },
+        {
+          plugins: [
+            i18n({
+              locale: 'ja-JP',
+              builtinResources: {
+                'ja-JP': {
+                  'err:arg:custom-parse': 'カスタム解析エラー: {$reason}'
+                }
+              }
+            })
+          ]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toEqual('カスタム解析エラー: Invalid port')
+  })
+})
+
 describe('positional arguments', () => {
   test('basic', async () => {
     const utils = await import('./utils.ts')

--- a/packages/gunshi/src/index.test-d.ts
+++ b/packages/gunshi/src/index.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf, test } from 'vitest'
+import { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from './index.ts'
+
+import type { ArgsValidationErrorCode } from './index.ts'
+
+test('exports args validation error types', () => {
+  expectTypeOf(ArgsValidationError).toBeConstructibleWith('fallback message')
+  expectTypeOf(ArgsValidationErrorKeys.requiredOption).toEqualTypeOf<'err:arg:required-option'>()
+  expectTypeOf<ArgsValidationErrorCode>().toEqualTypeOf<
+    (typeof ArgsValidationErrorKeys)[keyof typeof ArgsValidationErrorKeys]
+  >()
+  expectTypeOf(isArgsValidationError).toBeFunction()
+})

--- a/packages/gunshi/src/index.test.ts
+++ b/packages/gunshi/src/index.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from './index.ts'
+
+test('exports args validation error runtime API', () => {
+  const error = new ArgsValidationError('fallback message', {
+    code: ArgsValidationErrorKeys.requiredOption,
+    values: {
+      displayName: "'--id'"
+    }
+  })
+
+  expect(isArgsValidationError(error)).toBe(true)
+  expect(error.code).toBe(ArgsValidationErrorKeys.requiredOption)
+  expect(error.values).toEqual({
+    displayName: "'--id'"
+  })
+})

--- a/packages/gunshi/src/index.ts
+++ b/packages/gunshi/src/index.ts
@@ -26,7 +26,13 @@
  */
 
 export { DefaultTranslation } from '@gunshi/plugin-i18n' // TODO(kazupon): remove this import after the next major release
-export { parseArgs, resolveArgs } from 'args-tokens'
+export {
+  ArgsValidationError,
+  ArgsValidationErrorKeys,
+  isArgsValidationError,
+  parseArgs,
+  resolveArgs
+} from 'args-tokens'
 export * from './cli.ts'
 export { ANONYMOUS_COMMAND_NAME } from './constants.ts'
 export { createCommandContext } from './context.ts'
@@ -34,6 +40,7 @@ export { define, defineWithTypes, lazy, lazyWithTypes } from './definition.ts'
 export { plugin } from './plugin/core.ts'
 
 export type { CommandContextParams } from './context.ts'
+export type { ArgsValidationErrorCode } from 'args-tokens'
 export type { PluginContext } from './plugin/context.ts'
 export type {
   OnPluginExtension,

--- a/packages/gunshi/src/index.ts
+++ b/packages/gunshi/src/index.ts
@@ -9,7 +9,7 @@
  * - `lazyWithTypes`: A function to lazily load a command with specific type parameters.
  * - `plugin`: A function to create a plugin.
  * - `createCommandContext`: A function to create a command context, mainly for testing purposes.
- * - `args-tokens` utilities, `parseArgs` and `resolveArgs` for parsing command line arguments.
+ * - `args-tokens` utilities: `parseArgs`, `resolveArgs`, `ArgsValidationError`, `ArgsValidationErrorKeys`, `ArgsValidationErrorCode`, and `isArgsValidationError` for parsing and validating command line arguments.
  * - Some basic type definitions, such as `CommandContext`, `Plugin`, `PluginContext`, etc.
  *
  * @example

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -26,8 +26,10 @@
 export { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT } from './constants.ts'
 export { createCommandContext } from './context.ts'
 export { plugin } from './plugin/core.ts'
+export { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
 
 export type { CommandContextParams } from './context.ts'
+export type { ArgsValidationErrorCode } from 'args-tokens'
 export type { PluginContext } from './plugin/context.ts'
 export type {
   OnPluginExtension,

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -119,6 +119,32 @@ describe('extension: translate', () => {
         })
       ).toEqual("必須オプション: '--id'")
     })
+
+    test('partial builtinResources falls back to default locale per key', async () => {
+      const plugin = i18n({
+        locale: 'ja-JP',
+        builtinResources: {
+          'ja-JP': {
+            'err:arg:required-option': '必須オプション: {$displayName}'
+          }
+        }
+      })
+      const ctx = await createCommandContext({})
+      const extension = await plugin.extension.factory(ctx, {} as Command)
+
+      expect(extension.translate(resolveBuiltInKey('OPTIONS'))).toEqual('OPTIONS')
+      expect(
+        extension.translate('err:arg:required-option', {
+          displayName: "'--id'"
+        })
+      ).toEqual("必須オプション: '--id'")
+      expect(
+        extension.translate('err:arg:invalid-type', {
+          displayName: "'--count'",
+          type: 'number'
+        })
+      ).toEqual("Option '--count' must be of type number")
+    })
   })
 
   describe('translate non-built-in keys', () => {

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -66,6 +66,11 @@ describe('extension: translate', () => {
         'For more info, run any command with the `--help` flag'
       )
       expect(extension.translate(resolveBuiltInKey('NEGATABLE'))).toEqual('Negatable of')
+      expect(
+        extension.translate('err:arg:required-option', {
+          displayName: "'--id'"
+        })
+      ).toEqual("Optional argument '--id' is required")
     })
 
     test('custom locale: ja-JP', async () => {
@@ -89,6 +94,30 @@ describe('extension: translate', () => {
         '詳細は、コマンドと`--help`フラグを実行してください'
       )
       expect(extension.translate(resolveBuiltInKey('NEGATABLE'))).toEqual('否定可能な')
+      expect(
+        extension.translate('err:arg:required-option', {
+          displayName: "'--id'"
+        })
+      ).toEqual("オプション '--id' は必須です")
+    })
+
+    test('custom builtinResources can override args validation error keys', async () => {
+      const plugin = i18n({
+        locale: 'ja-JP',
+        builtinResources: {
+          'ja-JP': {
+            'err:arg:required-option': '必須オプション: {$displayName}'
+          }
+        }
+      })
+      const ctx = await createCommandContext({})
+      const extension = await plugin.extension.factory(ctx, {} as Command)
+
+      expect(
+        extension.translate('err:arg:required-option', {
+          displayName: "'--id'"
+        })
+      ).toEqual("必須オプション: '--id'")
     })
   })
 

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -143,7 +143,7 @@ describe('extension: translate', () => {
           displayName: "'--count'",
           expected: 'number'
         })
-      ).toEqual("Option '--count' must be of type number")
+      ).toEqual("Invalid value for '--count': expected number")
     })
   })
 

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -141,7 +141,7 @@ describe('extension: translate', () => {
       expect(
         extension.translate('err:arg:invalid-type', {
           displayName: "'--count'",
-          type: 'number'
+          expected: 'number'
         })
       ).toEqual("Option '--count' must be of type number")
     })

--- a/packages/plugin-i18n/src/index.ts
+++ b/packages/plugin-i18n/src/index.ts
@@ -39,6 +39,7 @@ import {
   BUILT_IN_PREFIX,
   COMMON_ARGS,
   DefaultResource,
+  ERROR_PREFIX_AND_KEY_SEPARATOR,
   namespacedId,
   resolveArgKey,
   resolveBuiltInKey,
@@ -56,7 +57,7 @@ import type {
   LazyCommand,
   PluginWithExtension
 } from '@gunshi/plugin'
-import type { BuiltinResourceKeys, CommandArgKeys, CommandBuiltinKeys } from '@gunshi/shared'
+import type { BuiltinResource, CommandArgKeys, CommandBuiltinKeys } from '@gunshi/shared'
 import type { CommandResource, I18nCommand, I18nExtension, I18nPluginOptions } from './types.ts'
 
 export { resolveArgKey, resolveBuiltInKey, resolveKey } from '@gunshi/shared'
@@ -85,8 +86,7 @@ export default function i18n(
   const localeStr = toLocaleString(locale)
 
   const builtinResources =
-    options.builtinResources ||
-    (Object.create(null) as Record<string, Record<BuiltinResourceKeys, string>>)
+    options.builtinResources || (Object.create(null) as Record<string, BuiltinResource>)
 
   // create translation adapter
   const translationAdapterFactory = options.translationAdapterFactory || createTranslationAdapter
@@ -155,11 +155,11 @@ export default function i18n(
         values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
       ): string {
         const strKey = key as string
-        if (strKey.codePointAt(0) === BUILT_IN_PREFIX_CODE) {
+        if (isBuiltinResourceKey(strKey)) {
           // handle built-in keys
           const resource =
             localeBuiltinResources.get(localeStr) || localeBuiltinResources.get(DEFAULT_LOCALE)!
-          return resource[strKey as CommandBuiltinKeys] || strKey
+          return formatResource(resource[strKey], values) || strKey
         } else {
           // handle command-specific keys
           return adapter.translate(localeStr, strKey, values) || ''
@@ -167,10 +167,7 @@ export default function i18n(
       }
 
       // define setResource function
-      function setResource(
-        locale: string | Intl.Locale,
-        resource: Record<BuiltinResourceKeys, string>
-      ): void {
+      function setResource(locale: string | Intl.Locale, resource: BuiltinResource): void {
         const targetLocale = toLocale(locale)
         const targetLocaleStr = toLocaleString(targetLocale)
         if (localeBuiltinResources.has(targetLocaleStr)) {
@@ -194,7 +191,10 @@ export default function i18n(
       for (const [locale, resource] of Object.entries(builtinResources)) {
         for (const globalOption of builtinGlobalOptions) {
           const globalOptionResource = builtinGlobalOptionResources[globalOption]
-          globalOptionResource[locale] = (resource as Record<string, string>)[globalOption]
+          const message = (resource as Record<string, string>)[globalOption]
+          if (message) {
+            globalOptionResource[locale] = message
+          }
         }
       }
       for (const globalOption of builtinGlobalOptions) {
@@ -202,7 +202,7 @@ export default function i18n(
       }
 
       // set default locale resources
-      setResource(DEFAULT_LOCALE, DefaultResource as Record<BuiltinResourceKeys, string>)
+      setResource(DEFAULT_LOCALE, DefaultResource as BuiltinResource)
 
       // install built-in locale resources
       for (const [locale, resource] of Object.entries(builtinResources)) {
@@ -320,18 +320,42 @@ async function loadCommandResource(
 }
 
 function mapResourceWithBuiltinKey(
-  resource: Record<string, string>,
+  resource: BuiltinResource,
   ctx: CommandContext,
   globalOptions: string[]
 ): Record<string, string> {
   return Object.entries(resource).reduce(
     (acc, [key, value]) => {
-      acc[globalOptions.includes(key) ? resolveArgKey(key, ctx.name) : resolveBuiltInKey(key)] =
-        value
+      if (value == null) {
+        return acc
+      }
+
+      acc[
+        key.startsWith(ERROR_PREFIX_AND_KEY_SEPARATOR)
+          ? key
+          : globalOptions.includes(key)
+            ? resolveArgKey(key, ctx.name)
+            : resolveBuiltInKey(key)
+      ] = value
       return acc
     },
     Object.create(null) as Record<string, string>
   )
+}
+
+function isBuiltinResourceKey(key: string): boolean {
+  return (
+    key.codePointAt(0) === BUILT_IN_PREFIX_CODE || key.startsWith(ERROR_PREFIX_AND_KEY_SEPARATOR)
+  )
+}
+
+function formatResource(
+  resource: string | undefined,
+  values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
+): string | undefined {
+  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
+    return values[name] == null ? '' : String(values[name])
+  })
 }
 
 function hasI18nResource<G extends GunshiParamsConstraint = DefaultGunshiParams>(

--- a/packages/plugin-i18n/src/index.ts
+++ b/packages/plugin-i18n/src/index.ts
@@ -40,6 +40,7 @@ import {
   COMMON_ARGS,
   DefaultResource,
   ERROR_PREFIX_AND_KEY_SEPARATOR,
+  formatResource,
   namespacedId,
   resolveArgKey,
   resolveBuiltInKey,
@@ -157,9 +158,9 @@ export default function i18n(
         const strKey = key as string
         if (isBuiltinResourceKey(strKey)) {
           // handle built-in keys
-          const resource =
-            localeBuiltinResources.get(localeStr) || localeBuiltinResources.get(DEFAULT_LOCALE)!
-          return formatResource(resource[strKey], values) || strKey
+          const resource = localeBuiltinResources.get(localeStr)
+          const defaultResource = localeBuiltinResources.get(DEFAULT_LOCALE)!
+          return formatResource(resource?.[strKey] ?? defaultResource[strKey], values) || strKey
         } else {
           // handle command-specific keys
           return adapter.translate(localeStr, strKey, values) || ''
@@ -347,15 +348,6 @@ function isBuiltinResourceKey(key: string): boolean {
   return (
     key.codePointAt(0) === BUILT_IN_PREFIX_CODE || key.startsWith(ERROR_PREFIX_AND_KEY_SEPARATOR)
   )
-}
-
-function formatResource(
-  resource: string | undefined,
-  values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
-): string | undefined {
-  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
-    return values[name] == null ? '' : String(values[name])
-  })
 }
 
 function hasI18nResource<G extends GunshiParamsConstraint = DefaultGunshiParams>(

--- a/packages/plugin-i18n/src/types.test-d.ts
+++ b/packages/plugin-i18n/src/types.test-d.ts
@@ -1,7 +1,12 @@
 import { describe, expectTypeOf, test } from 'vitest'
 
 import type { Awaitable, Command, Prettify } from '@gunshi/plugin'
-import type { CommandResource, CommandResourceFetcher, I18nCommand } from './types.ts'
+import type {
+  CommandResource,
+  CommandResourceFetcher,
+  I18nCommand,
+  I18nPluginOptions
+} from './types.ts'
 
 const _args = {
   force: { type: 'boolean' },
@@ -39,6 +44,20 @@ describe('CommandResource', () => {
       CommandResource<{ description: string; args: typeof _args; extensions: typeof _extensions }>
     >
     expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+})
+
+describe('I18nPluginOptions', () => {
+  test('builtinResources accepts args validation error keys', () => {
+    const options = {
+      builtinResources: {
+        'ja-JP': {
+          'err:arg:required-option': 'オプション {$displayName} は必須です'
+        }
+      }
+    } satisfies I18nPluginOptions
+
+    expectTypeOf(options).toMatchTypeOf<I18nPluginOptions>()
   })
 })
 

--- a/packages/plugin-i18n/src/types.ts
+++ b/packages/plugin-i18n/src/types.ts
@@ -16,7 +16,7 @@ import type {
 import { ARG_PREFIX, namespacedId, PLUGIN_PREFIX } from '@gunshi/shared'
 
 import type {
-  BuiltinResourceKeys,
+  BuiltinResource,
   GenerateNamespacedKey,
   KeyOfArgs,
   RemovedIndex,
@@ -103,7 +103,7 @@ export interface I18nPluginOptions {
   /**
    * Built-in localizable resources
    */
-  builtinResources?: Record<string, Record<BuiltinResourceKeys, string>>
+  builtinResources?: Record<string, BuiltinResource>
 }
 
 /**

--- a/packages/plugin-renderer/package.json
+++ b/packages/plugin-renderer/package.json
@@ -60,8 +60,7 @@
     "typecheck:deno": "deno check --import-map=../../importmap.json ./src"
   },
   "dependencies": {
-    "@gunshi/plugin": "workspace:*",
-    "args-tokens": "catalog:"
+    "@gunshi/plugin": "workspace:*"
   },
   "peerDependencies": {
     "@gunshi/plugin-i18n": "workspace:*"

--- a/packages/plugin-renderer/package.json
+++ b/packages/plugin-renderer/package.json
@@ -60,7 +60,8 @@
     "typecheck:deno": "deno check --import-map=../../importmap.json ./src"
   },
   "dependencies": {
-    "@gunshi/plugin": "workspace:*"
+    "@gunshi/plugin": "workspace:*",
+    "args-tokens": "catalog:"
   },
   "peerDependencies": {
     "@gunshi/plugin-i18n": "workspace:*"

--- a/packages/plugin-renderer/src/validation.test.ts
+++ b/packages/plugin-renderer/src/validation.test.ts
@@ -28,7 +28,7 @@ test('basic', async () => {
   )
 })
 
-test('args validation error uses default resource', async () => {
+test('args validation error keeps fallback message without i18n', async () => {
   const ctx = await createCommandContext({
     cliOptions: {
       cwd: '/path/to/cmd1',
@@ -37,7 +37,7 @@ test('args validation error uses default resource', async () => {
     }
   })
   const error = new AggregateError([
-    new ArgsValidationError(`Optional argument '--id' is required`, {
+    new ArgsValidationError('fallback required option message', {
       code: ArgsValidationErrorKeys.requiredOption,
       values: {
         displayName: "'--id'"
@@ -46,7 +46,7 @@ test('args validation error uses default resource', async () => {
   ])
 
   await expect(renderValidationErrors(ctx, error)).resolves.toEqual(
-    `Optional argument '--id' is required`
+    'fallback required option message'
   )
 })
 

--- a/packages/plugin-renderer/src/validation.test.ts
+++ b/packages/plugin-renderer/src/validation.test.ts
@@ -1,6 +1,11 @@
+import i18n from '@gunshi/plugin-i18n'
+import { ArgsValidationError, ArgsValidationErrorKeys } from 'args-tokens'
 import { expect, test } from 'vitest'
 import { createCommandContext } from '../../gunshi/src/context.ts'
+import renderer from './index.ts'
 import { renderValidationErrors } from './validation.ts'
+
+import type { Command, CommandContext } from '@gunshi/plugin'
 
 test('basic', async () => {
   const ctx = await createCommandContext({
@@ -20,5 +25,122 @@ test('basic', async () => {
       `Optional argument '--dependency' or '-d' is required`,
       `Optional argument '--alias' or '-a' is required`
     ].join('\n')
+  )
+})
+
+test('args validation error uses default resource', async () => {
+  const ctx = await createCommandContext({
+    cliOptions: {
+      cwd: '/path/to/cmd1',
+      version: '0.0.0',
+      name: 'cmd1'
+    }
+  })
+  const error = new AggregateError([
+    new ArgsValidationError(`Optional argument '--id' is required`, {
+      code: ArgsValidationErrorKeys.requiredOption,
+      values: {
+        displayName: "'--id'"
+      }
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual(
+    `Optional argument '--id' is required`
+  )
+})
+
+test('args validation error falls back to message for unknown code', async () => {
+  const ctx = await createCommandContext({
+    cliOptions: {
+      cwd: '/path/to/cmd1',
+      version: '0.0.0',
+      name: 'cmd1'
+    }
+  })
+  const error = new AggregateError([
+    new ArgsValidationError('fallback message', {
+      code: 'err:arg:unknown-test' as typeof ArgsValidationErrorKeys.requiredOption
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual('fallback message')
+})
+
+test('args validation error uses i18n resource', async () => {
+  const i18nPlugin = i18n({
+    locale: 'ja-JP',
+    builtinResources: {
+      'ja-JP': {
+        'err:arg:required-option': '必須オプション: {$displayName}'
+      }
+    }
+  })
+  const rendererPlugin = renderer()
+  const command = {
+    name: 'test',
+    run: async () => {}
+  } as Command
+  const ctx = await createCommandContext({
+    command,
+    extensions: {
+      [i18nPlugin.id]: i18nPlugin.extension,
+      [rendererPlugin.id]: rendererPlugin.extension
+    }
+  })
+  const error = new AggregateError([
+    new ArgsValidationError(`Optional argument '--id' is required`, {
+      code: ArgsValidationErrorKeys.requiredOption,
+      values: {
+        displayName: "'--id'"
+      }
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual("必須オプション: '--id'")
+})
+
+test('custom parse reasonKey uses command resource', async () => {
+  const i18nPlugin = i18n({
+    locale: 'ja-JP',
+    builtinResources: {
+      'ja-JP': {
+        'err:arg:custom-parse': '{$displayName} の値が不正です: {$reason}'
+      }
+    }
+  })
+  const rendererPlugin = renderer()
+  const command = {
+    name: 'test',
+    resource: () => ({
+      'errors.invalidDateFormat': '日付形式が不正です。{$expected} 形式で指定してください'
+    }),
+    run: async () => {}
+  } as Command
+  const ctx = await createCommandContext({
+    command,
+    extensions: {
+      [i18nPlugin.id]: i18nPlugin.extension,
+      [rendererPlugin.id]: rendererPlugin.extension
+    }
+  })
+  await ctx.extensions[i18nPlugin.id].loadResource('ja-JP', ctx as CommandContext, command)
+
+  const error = new AggregateError([
+    new ArgsValidationError('Invalid value for --date: Invalid date format', {
+      code: ArgsValidationErrorKeys.customParse,
+      values: {
+        displayName: '--date',
+        reason: 'Invalid date format',
+        reasonKey: 'errors.invalidDateFormat',
+        reasonValues: {
+          expected: 'YYYY-MM-DD'
+        }
+      }
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual(
+    '--date の値が不正です: 日付形式が不正です。YYYY-MM-DD 形式で指定してください'
   )
 })

--- a/packages/plugin-renderer/src/validation.test.ts
+++ b/packages/plugin-renderer/src/validation.test.ts
@@ -1,5 +1,5 @@
 import i18n from '@gunshi/plugin-i18n'
-import { ArgsValidationError, ArgsValidationErrorKeys } from 'args-tokens'
+import { ArgsValidationError, ArgsValidationErrorKeys } from '@gunshi/plugin'
 import { expect, test } from 'vitest'
 import { createCommandContext } from '../../gunshi/src/context.ts'
 import renderer from './index.ts'

--- a/packages/plugin-renderer/src/validation.ts
+++ b/packages/plugin-renderer/src/validation.ts
@@ -3,22 +3,103 @@
  * @license MIT
  */
 
+import { ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
+import { DefaultResource, resolveKey } from '@gunshi/shared'
+import { pluginId } from './types.ts'
+
 import type { CommandContext, DefaultGunshiParams, GunshiParams } from '@gunshi/plugin'
+import type { ArgsValidationError } from 'args-tokens'
 
 /**
  * Render the validation errors.
  *
- * @param _ctx - A {@link CommandContext | command context}
+ * @param ctx - A {@link CommandContext | command context}
  * @param error - An {@link AggregateError} of option in `args-token` validation
  * @returns A rendered validation error.
  */
-export function renderValidationErrors<G extends GunshiParams = DefaultGunshiParams>(
-  _ctx: CommandContext<G>,
+export async function renderValidationErrors<G extends GunshiParams = DefaultGunshiParams>(
+  ctx: CommandContext<G>,
   error: AggregateError
 ): Promise<string> {
   const messages = [] as string[]
   for (const err of error.errors as Error[]) {
-    messages.push(err.message)
+    messages.push(await renderValidationError(ctx, err))
   }
-  return Promise.resolve(messages.join('\n'))
+  return messages.join('\n')
+}
+
+async function renderValidationError<G extends GunshiParams = DefaultGunshiParams>(
+  ctx: CommandContext<G>,
+  error: Error
+): Promise<string> {
+  if (isArgsValidationError(error) && error.code) {
+    const values = await resolveValidationValues(ctx, error)
+    const message = await localize(ctx, error.code, values)
+    if (message && message !== error.code) {
+      return message
+    }
+  }
+
+  return error.message
+}
+
+async function resolveValidationValues<G extends GunshiParams = DefaultGunshiParams>(
+  ctx: CommandContext<G>,
+  error: ArgsValidationError
+): Promise<Record<string, unknown>> {
+  if (error.code !== ArgsValidationErrorKeys.customParse) {
+    return error.values
+  }
+
+  const { reason, reasonKey, reasonValues } = error.values
+  if (typeof reasonKey !== 'string') {
+    return error.values
+  }
+
+  const key = resolveKey(reasonKey, ctx.name)
+  const localizedReason = await localize(ctx, key, toRecord(reasonValues))
+  if (!localizedReason || localizedReason === key) {
+    return error.values
+  }
+
+  return {
+    ...error.values,
+    reason: localizedReason || reason
+  }
+}
+
+async function localize<G extends GunshiParams = DefaultGunshiParams>(
+  ctx: CommandContext<G>,
+  key: string,
+  values?: Record<string, unknown>
+): Promise<string> {
+  const renderer = (
+    ctx.extensions as
+      | Record<
+          string,
+          { text?: (key: string, values?: Record<string, unknown>) => Promise<string> }
+        >
+      | undefined
+  )?.[pluginId]
+
+  if (renderer?.text) {
+    return await renderer.text(key, values)
+  }
+
+  return formatResource(DefaultResource[key as keyof typeof DefaultResource], values) || key
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value != null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : (Object.create(null) as Record<string, unknown>)
+}
+
+function formatResource(
+  resource: string | undefined,
+  values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
+): string | undefined {
+  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
+    return values[name] == null ? '' : String(values[name])
+  })
 }

--- a/packages/plugin-renderer/src/validation.ts
+++ b/packages/plugin-renderer/src/validation.ts
@@ -4,11 +4,12 @@
  */
 
 import { ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
-import { DefaultResource, resolveKey } from '@gunshi/shared'
-import { pluginId } from './types.ts'
+import { namespacedId, resolveKey } from '@gunshi/shared'
 
 import type { CommandContext, DefaultGunshiParams, GunshiParams } from '@gunshi/plugin'
 import type { ArgsValidationError } from 'args-tokens'
+
+const i18nPluginId = namespacedId('i18n')
 
 /**
  * Render the validation errors.
@@ -73,33 +74,21 @@ async function localize<G extends GunshiParams = DefaultGunshiParams>(
   key: string,
   values?: Record<string, unknown>
 ): Promise<string> {
-  const renderer = (
+  const i18n = (
     ctx.extensions as
-      | Record<
-          string,
-          { text?: (key: string, values?: Record<string, unknown>) => Promise<string> }
-        >
+      | Record<string, { translate?: (key: string, values?: Record<string, unknown>) => string }>
       | undefined
-  )?.[pluginId]
+  )?.[i18nPluginId]
 
-  if (renderer?.text) {
-    return await renderer.text(key, values)
+  if (i18n?.translate) {
+    return i18n.translate(key, values)
   }
 
-  return formatResource(DefaultResource[key as keyof typeof DefaultResource], values) || key
+  return key
 }
 
 function toRecord(value: unknown): Record<string, unknown> {
   return value != null && typeof value === 'object'
     ? (value as Record<string, unknown>)
     : (Object.create(null) as Record<string, unknown>)
-}
-
-function formatResource(
-  resource: string | undefined,
-  values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
-): string | undefined {
-  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
-    return values[name] == null ? '' : String(values[name])
-  })
 }

--- a/packages/plugin-renderer/src/validation.ts
+++ b/packages/plugin-renderer/src/validation.ts
@@ -3,11 +3,15 @@
  * @license MIT
  */
 
-import { ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
+import { ArgsValidationErrorKeys, isArgsValidationError } from '@gunshi/plugin'
 import { namespacedId, resolveKey } from '@gunshi/shared'
 
-import type { CommandContext, DefaultGunshiParams, GunshiParams } from '@gunshi/plugin'
-import type { ArgsValidationError } from 'args-tokens'
+import type {
+  ArgsValidationError,
+  CommandContext,
+  DefaultGunshiParams,
+  GunshiParams
+} from '@gunshi/plugin'
 
 const i18nPluginId = namespacedId('i18n')
 
@@ -52,7 +56,7 @@ async function resolveValidationValues<G extends GunshiParams = DefaultGunshiPar
     return error.values
   }
 
-  const { reason, reasonKey, reasonValues } = error.values
+  const { reasonKey, reasonValues } = error.values
   if (typeof reasonKey !== 'string') {
     return error.values
   }
@@ -65,7 +69,7 @@ async function resolveValidationValues<G extends GunshiParams = DefaultGunshiPar
 
   return {
     ...error.values,
-    reason: localizedReason || reason
+    reason: localizedReason
   }
 }
 

--- a/packages/resources/locales/en-US.json
+++ b/packages/resources/locales/en-US.json
@@ -11,5 +11,11 @@
   "DEFAULT": "default",
   "CHOICES": "choices",
   "help": "Display this help message",
-  "version": "Display this version"
+  "version": "Display this version",
+  "err:arg:required-option": "Optional argument {$displayName} is required",
+  "err:arg:required-positional": "Positional argument {$name} is required",
+  "err:arg:invalid-type": "Invalid value for {$displayName}: expected {$expected}",
+  "err:arg:invalid-choice": "Invalid value for {$displayName}: expected one of {$choices}",
+  "err:arg:custom-parse": "Invalid value for {$displayName}: {$reason}",
+  "err:arg:unknown-option": "Unknown option: {$rawName}"
 }

--- a/packages/resources/locales/ja-JP.json
+++ b/packages/resources/locales/ja-JP.json
@@ -11,5 +11,11 @@
   "DEFAULT": "デフォルト",
   "CHOICES": "選択肢",
   "help": "このヘルプメッセージを表示",
-  "version": "このバージョンを表示"
+  "version": "このバージョンを表示",
+  "err:arg:required-option": "オプション {$displayName} は必須です",
+  "err:arg:required-positional": "位置引数 {$name} は必須です",
+  "err:arg:invalid-type": "{$displayName} の値が不正です。期待される型: {$expected}",
+  "err:arg:invalid-choice": "{$displayName} の値が不正です。指定可能な値: {$choices}",
+  "err:arg:custom-parse": "{$displayName} の値が不正です: {$reason}",
+  "err:arg:unknown-option": "未定義のオプションです: {$rawName}"
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -9,11 +9,15 @@ export const PLUGIN_PREFIX = 'g'
 
 export const ARG_PREFIX = 'arg'
 
+export const ERROR_PREFIX = 'err'
+
 export const BUILT_IN_KEY_SEPARATOR = ':'
 
 export const BUILD_IN_PREFIX_AND_KEY_SEPARATOR: string = `${BUILT_IN_PREFIX}${BUILT_IN_KEY_SEPARATOR}`
 
 export const ARG_PREFIX_AND_KEY_SEPARATOR: string = `${ARG_PREFIX}${BUILT_IN_KEY_SEPARATOR}`
+
+export const ERROR_PREFIX_AND_KEY_SEPARATOR: string = `${ERROR_PREFIX}${BUILT_IN_KEY_SEPARATOR}`
 
 export const ARG_NEGATABLE_PREFIX = 'no-'
 
@@ -55,4 +59,13 @@ export const COMMAND_BUILTIN_RESOURCE_KEYS = [
   'NEGATABLE',
   'DEFAULT',
   'CHOICES'
+] as const
+
+export const ARG_ERROR_RESOURCE_KEYS = [
+  'err:arg:required-option',
+  'err:arg:required-positional',
+  'err:arg:invalid-type',
+  'err:arg:invalid-choice',
+  'err:arg:custom-parse',
+  'err:arg:unknown-option'
 ] as const

--- a/packages/shared/src/localization.test.ts
+++ b/packages/shared/src/localization.test.ts
@@ -65,6 +65,18 @@ describe('without translation function', () => {
     expect(await localize(resolveBuiltInKey('help'))).toEqual('Display this help message')
   })
 
+  test('args validation error keys', async () => {
+    const { ctx, command1 } = await setup()
+    const localize = localizable(ctx, command1)
+
+    expect(
+      await localize('err:arg:required-option', {
+        displayName: "'--id'"
+      })
+    ).toEqual("Optional argument '--id' is required")
+    expect(await localize('err:arg:not-found')).toEqual('err:arg:not-found')
+  })
+
   test('gunshi args keys', async () => {
     const { ctx, command1 } = await setup()
     const localize = localizable<

--- a/packages/shared/src/localization.ts
+++ b/packages/shared/src/localization.ts
@@ -6,7 +6,8 @@
 import {
   ARG_NEGATABLE_PREFIX,
   ARG_PREFIX_AND_KEY_SEPARATOR,
-  BUILD_IN_PREFIX_AND_KEY_SEPARATOR
+  BUILD_IN_PREFIX_AND_KEY_SEPARATOR,
+  ERROR_PREFIX_AND_KEY_SEPARATOR
 } from './constants.ts'
 import DefaultResource from './resource.ts'
 import { makeShortLongOptionPair, resolveExamples, resolveKey } from './utils.ts'
@@ -56,7 +57,17 @@ export function localizable<
 
     if ((key as string).startsWith(BUILD_IN_PREFIX_AND_KEY_SEPARATOR)) {
       const resKey = (key as string).slice(BUILD_IN_PREFIX_AND_KEY_SEPARATOR.length)
-      return DefaultResource[resKey as keyof typeof DefaultResource] || (key as string)
+      return (
+        formatResource(DefaultResource[resKey as keyof typeof DefaultResource], values) ||
+        (key as string)
+      )
+    }
+
+    if ((key as string).startsWith(ERROR_PREFIX_AND_KEY_SEPARATOR)) {
+      return (
+        formatResource(DefaultResource[key as keyof typeof DefaultResource], values) ||
+        (key as string)
+      )
     }
 
     const namaspacedArgKey = resolveKey(ARG_PREFIX_AND_KEY_SEPARATOR, ctx.name)
@@ -87,4 +98,13 @@ export function localizable<
   }
 
   return localize as unknown as Localization<A, C, E>
+}
+
+function formatResource(
+  resource: string | undefined,
+  values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
+): string | undefined {
+  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
+    return values[name] == null ? '' : String(values[name])
+  })
 }

--- a/packages/shared/src/localization.ts
+++ b/packages/shared/src/localization.ts
@@ -57,17 +57,11 @@ export function localizable<
 
     if ((key as string).startsWith(BUILD_IN_PREFIX_AND_KEY_SEPARATOR)) {
       const resKey = (key as string).slice(BUILD_IN_PREFIX_AND_KEY_SEPARATOR.length)
-      return (
-        formatResource(DefaultResource[resKey as keyof typeof DefaultResource], values) ||
-        (key as string)
-      )
+      return resolveAndFormatResource(resKey, key as string, values)
     }
 
     if ((key as string).startsWith(ERROR_PREFIX_AND_KEY_SEPARATOR)) {
-      return (
-        formatResource(DefaultResource[key as keyof typeof DefaultResource], values) ||
-        (key as string)
-      )
+      return resolveAndFormatResource(key as string, key as string, values)
     }
 
     const namaspacedArgKey = resolveKey(ARG_PREFIX_AND_KEY_SEPARATOR, ctx.name)
@@ -100,11 +94,22 @@ export function localizable<
   return localize as unknown as Localization<A, C, E>
 }
 
-function formatResource(
+function resolveAndFormatResource(
+  resourceKey: string,
+  fallbackKey: string,
+  values?: Record<string, unknown>
+): string {
+  return (
+    formatResource(DefaultResource[resourceKey as keyof typeof DefaultResource], values) ||
+    fallbackKey
+  )
+}
+
+export function formatResource(
   resource: string | undefined,
   values: Record<string, unknown> = Object.create(null) as Record<string, unknown>
 ): string | undefined {
-  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string | RegExp, name: string): string => {
+  return resource?.replaceAll(/\{\$(\w+)\}/g, (_: string, name: string): string => {
     return values[name] == null ? '' : String(values[name])
   })
 }

--- a/packages/shared/src/localization.ts
+++ b/packages/shared/src/localization.ts
@@ -105,6 +105,13 @@ function resolveAndFormatResource(
   )
 }
 
+/**
+ * Format a resource message by replacing placeholder values.
+ *
+ * @param resource - Resource message template
+ * @param values - Placeholder values
+ * @returns Formatted resource message
+ */
 export function formatResource(
   resource: string | undefined,
   values: Record<string, unknown> = Object.create(null) as Record<string, unknown>

--- a/packages/shared/src/types.test-d.ts
+++ b/packages/shared/src/types.test-d.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import type { Args } from 'gunshi'
 import type {
+  ArgErrorResourceKeys,
   CommandArgKeys,
   CommandBuiltinKeys,
   ResolveTranslationKeys,
@@ -49,7 +50,7 @@ describe('ResolveTranslationKeys', () => {
     } satisfies Args
 
     expectTypeOf<ResolveTranslationKeys<typeof _args>>().toEqualTypeOf<
-      'arg:foo' | 'arg:bar' | 'arg:no-bar' | CommandBuiltinKeys
+      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ArgErrorResourceKeys | CommandBuiltinKeys
     >()
   })
 
@@ -72,7 +73,11 @@ describe('ResolveTranslationKeys', () => {
     } as const
 
     expectTypeOf<ResolveTranslationKeys<typeof _args, typeof _ctx>>().toEqualTypeOf<
-      'test:arg:foo' | 'test:arg:bar' | 'test:arg:no-bar' | CommandBuiltinKeys
+      | 'test:arg:foo'
+      | 'test:arg:bar'
+      | 'test:arg:no-bar'
+      | ArgErrorResourceKeys
+      | CommandBuiltinKeys
     >()
   })
 
@@ -93,7 +98,7 @@ describe('ResolveTranslationKeys', () => {
     const _ctx = {} as const
 
     expectTypeOf<ResolveTranslationKeys<typeof _args, typeof _ctx>>().toEqualTypeOf<
-      'arg:foo' | 'arg:bar' | 'arg:no-bar' | CommandBuiltinKeys
+      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ArgErrorResourceKeys | CommandBuiltinKeys
     >()
   })
 
@@ -125,6 +130,7 @@ describe('ResolveTranslationKeys', () => {
       | 'test:arg:foo'
       | 'test:arg:bar'
       | 'test:arg:no-bar'
+      | ArgErrorResourceKeys
       | CommandBuiltinKeys
       | 'test:customResource'
     >()

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  ARG_ERROR_RESOURCE_KEYS,
   ARG_PREFIX,
   BUILT_IN_KEY_SEPARATOR,
   BUILT_IN_PREFIX,
@@ -67,6 +68,11 @@ export type CommandBuiltinArgsKeys = keyof typeof COMMON_ARGS
 export type CommandBuiltinResourceKeys = (typeof COMMAND_BUILTIN_RESOURCE_KEYS)[number]
 
 /**
+ * Args validation error resource keys.
+ */
+export type ArgErrorResourceKeys = (typeof ARG_ERROR_RESOURCE_KEYS)[number]
+
+/**
  * Built-in resource keys.
  */
 export type BuiltinResourceKeys = CommandBuiltinArgsKeys | CommandBuiltinResourceKeys
@@ -103,7 +109,7 @@ export type ResolveTranslationKeys<
       : R
     : R | CommandBuiltinKeys,
   O = CommandArgKeys<A, C>
-> = CommandBuiltinKeys | O | T
+> = ArgErrorResourceKeys | CommandBuiltinKeys | O | T
 
 /**
  * Translation function interface

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -75,12 +75,22 @@ export type ArgErrorResourceKeys = (typeof ARG_ERROR_RESOURCE_KEYS)[number]
 /**
  * Built-in resource keys.
  */
-export type BuiltinResourceKeys = CommandBuiltinArgsKeys | CommandBuiltinResourceKeys
+export type BuiltinResourceKeys =
+  | ArgErrorResourceKeys
+  | CommandBuiltinArgsKeys
+  | CommandBuiltinResourceKeys
+
+/**
+ * Built-in resource.
+ */
+export type BuiltinResource = Partial<Record<BuiltinResourceKeys, string>>
 
 /**
  * Command built-in keys.
  */
-export type CommandBuiltinKeys = GenerateNamespacedKey<BuiltinResourceKeys>
+export type CommandBuiltinKeys = GenerateNamespacedKey<
+  CommandBuiltinArgsKeys | CommandBuiltinResourceKeys
+>
 
 /**
  * Command i18n option keys.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^25.6.2
       version: 25.9.2
     args-tokens:
-      specifier: ^0.27.0
-      version: 0.27.0
+      specifier: ^0.28.0
+      version: 0.28.0
     deno:
       specifier: ^2.7.14
       version: 2.8.2
@@ -247,7 +247,7 @@ importers:
         version: 14.3.0(vue@3.5.35(typescript@6.0.3))
       args-tokens:
         specifier: 'catalog:'
-        version: 0.27.0
+        version: 0.28.0
       mermaid:
         specifier: ^11.12.0
         version: 11.15.0
@@ -295,7 +295,7 @@ importers:
         version: link:../shared
       args-tokens:
         specifier: 'catalog:'
-        version: 0.27.0
+        version: 0.28.0
       deno:
         specifier: 'catalog:'
         version: 2.8.2
@@ -2053,12 +2053,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.1.2':
-    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2067,12 +2061,6 @@ packages:
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-arm64@1.1.2':
-    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2089,12 +2077,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.2':
-    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-x64@1.1.3':
     resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2103,12 +2085,6 @@ packages:
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-freebsd-x64@1.1.2':
-    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2125,12 +2101,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
-    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
     resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2139,13 +2109,6 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
-    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2165,13 +2128,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
-    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2181,13 +2137,6 @@ packages:
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
-    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2207,13 +2156,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
-    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2223,13 +2165,6 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
-    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2249,13 +2184,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
-    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2265,12 +2193,6 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-openharmony-arm64@1.1.2':
-    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2286,11 +2208,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.1.3':
     resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2298,12 +2215,6 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2316,12 +2227,6 @@ packages:
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
-    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2979,8 +2884,8 @@ packages:
     resolution: {integrity: sha512-kWceoEa1zXbcBvgy+BT1ddTLyB7B51u32EhOK/ZMY324nxmQAm767HD+g+9avBEPVmoDjWIYLvsSCQqtbcph/g==}
     engines: {node: '>= 20'}
 
-  args-tokens@0.27.0:
-    resolution: {integrity: sha512-bA4QwSNK94NG99lTZSxqCpKwQOMAfmK9If3nt1udvFTIY3b6Vj/3QzpXuOtegiYh2197zQLc8eejKDJm8Emj/g==}
+  args-tokens@0.28.0:
+    resolution: {integrity: sha512-jZVhQzAB7jr87SphE8+ZbpB98BUCGuR/+vuH9jDAdbXOakHQRVsXWH68Q2IPxpyxjc2Zu/ROLqS9rPaDbU13Xg==}
     engines: {node: '>= 22'}
 
   array-find-index@1.0.2:
@@ -4423,11 +4328,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.1.2:
-    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.1.3:
     resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5778,16 +5678,10 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.1.2':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.1.2':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.1.3':
@@ -5796,16 +5690,10 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.2':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.1.3':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.1.2':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.1.3':
@@ -5814,16 +5702,10 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.1.3':
@@ -5832,16 +5714,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
@@ -5850,16 +5726,10 @@ snapshots:
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
@@ -5868,16 +5738,10 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.1.3':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.1.2':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
@@ -5890,13 +5754,6 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
   '@rolldown/binding-wasm32-wasi@1.1.3':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5907,16 +5764,10 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.1.3':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.1.3':
@@ -6562,7 +6413,7 @@ snapshots:
 
   args-tokens@0.17.1: {}
 
-  args-tokens@0.27.0: {}
+  args-tokens@0.28.0: {}
 
   array-find-index@1.0.2: {}
 
@@ -8343,27 +8194,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rolldown@1.1.2:
-    dependencies:
-      '@oxc-project/types': 0.137.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.2
-      '@rolldown/binding-darwin-arm64': 1.1.2
-      '@rolldown/binding-darwin-x64': 1.1.2
-      '@rolldown/binding-freebsd-x64': 1.1.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
-      '@rolldown/binding-linux-arm64-gnu': 1.1.2
-      '@rolldown/binding-linux-arm64-musl': 1.1.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
-      '@rolldown/binding-linux-s390x-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-musl': 1.1.2
-      '@rolldown/binding-openharmony-arm64': 1.1.2
-      '@rolldown/binding-wasm32-wasi': 1.1.2
-      '@rolldown/binding-win32-arm64-msvc': 1.1.2
-      '@rolldown/binding-win32-x64-msvc': 1.1.2
-
   rolldown@1.1.3:
     dependencies:
       '@oxc-project/types': 0.137.0
@@ -8803,7 +8633,7 @@ snapshots:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.1.2
+      rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,9 +477,6 @@ importers:
       '@gunshi/plugin-i18n':
         specifier: workspace:*
         version: link:../plugin-i18n
-      args-tokens:
-        specifier: 'catalog:'
-        version: 0.28.0
     devDependencies:
       '@gunshi/shared':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       '@gunshi/plugin-i18n':
         specifier: workspace:*
         version: link:../plugin-i18n
+      args-tokens:
+        specifier: 'catalog:'
+        version: 0.28.0
     devDependencies:
       '@gunshi/shared':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   "@types/node": ^25.6.2
   vitepress-api-references: ^0.2.1
   tsx: ^4.21.0
-  args-tokens: ^0.27.0
+  args-tokens: ^0.28.0
 overrides:
   # Pin rolldown to 1.0.0 (GA). Without this, tsdown@0.21.0 resolves to
   # rolldown@1.0.0-rc.7, whose `@rolldown/binding-*` optional dependencies


### PR DESCRIPTION
Summary

This PR wires args-token validation metadata into Gunshi so built-in argument validation errors carry stable err:arg:* codes and interpolation values.

The i18n plugin can now resolve those keys from user resources, while the renderer localizes validation output only when the i18n extension is active and otherwise preserves existing fallback messages.

It also re-exports validation error helpers from gunshi, adds CLI integration coverage for required, type, choice, and custom parse errors, and ignores local planning notes.

Validation: pnpm test, pnpm lint:typecheck, pnpm build, pnpm lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized validation messages for CLI arguments and options, including required values, invalid types, invalid choices, custom parse errors, and unknown options.
  * Improved translation support so error messages can be formatted with dynamic values like display names and reasons.

* **Bug Fixes**
  * Validation and rendering now fall back more reliably when a translation is missing.
  * Error messages are now consistently localized across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->