### PR TITLE
feat: add strict unknown option validation

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Intentional misspelling used in strict unknown-option tests and docs.
+alow = "alow"

--- a/e2e/fixture/plugins/getting-started/adding-global/enable-debug.snap
+++ b/e2e/fixture/plugins/getting-started/adding-global/enable-debug.snap
@@ -16,6 +16,7 @@ Context: [Object: null prototype] {
     middleMargin: 10,
     usageOptionType: false,
     usageOptionValue: true,
+    strict: false,
     renderHeader: [Function: renderer],
     renderUsage: [Function: renderer],
     renderValidationErrors: [Function: renderer],

--- a/packages/docs/src/guide/essentials/declarative.md
+++ b/packages/docs/src/guide/essentials/declarative.md
@@ -297,6 +297,24 @@ Custom type arguments support:
 - **Multiple values**: Set `multiple: true` to allow multiple instances of the argument
 - **Short aliases**: Set a `short` property to provide a single-character alias
 
+#### Strict Unknown Option Validation
+
+By default, Gunshi keeps backward compatibility by ignoring option tokens that are not declared in the resolved command's `args` or installed global options. Enable `strict` when you want typos or unsupported options to fail before the command runner executes:
+
+```js
+await cli(process.argv.slice(2), command, {
+  strict: true
+})
+```
+
+With `strict: true`, an input such as `--alow-reload` is reported as an argument validation error:
+
+```txt
+Unknown option: --alow-reload
+```
+
+The error uses the `err:arg:unknown-option` resource key, so the message follows the same renderer and i18n behavior as other argument validation errors. Suggestions such as `Did you mean --allow-reload?` are intentionally left to suggestion plugins.
+
 #### Kebab-Case Argument Names
 
 <!-- eslint-disable markdown/no-missing-label-refs -->

--- a/packages/gunshi/src/cli.test-d.ts
+++ b/packages/gunshi/src/cli.test-d.ts
@@ -97,3 +97,16 @@ test('CommandContext has commandPath accessible', () => {
   type Ctx = CommandContext
   expectTypeOf<Ctx['commandPath']>().toEqualTypeOf<string[]>()
 })
+
+test('cli() accepts strict option', async () => {
+  await cli(
+    [],
+    define({
+      name: 'strict',
+      run: () => {}
+    }),
+    {
+      strict: true
+    }
+  )
+})

--- a/packages/gunshi/src/cli.test-d.ts
+++ b/packages/gunshi/src/cli.test-d.ts
@@ -98,15 +98,13 @@ test('CommandContext has commandPath accessible', () => {
   expectTypeOf<Ctx['commandPath']>().toEqualTypeOf<string[]>()
 })
 
-test('cli() accepts strict option', async () => {
-  await cli(
+test('cli() accepts strict option', () => {
+  expectTypeOf(cli).toBeCallableWith(
     [],
     define({
       name: 'strict',
       run: () => {}
     }),
-    {
-      strict: true
-    }
+    { strict: true }
   )
 })

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4-mini'
 import i18n from '../../plugin-i18n/src/index.ts'
 import { defineMockLog } from '../test/utils.ts'
 import { cli } from './cli.ts'
+import { cli as boneCli } from './cli/bone.ts'
 import { define, lazy } from './definition.ts'
 import { generate } from './generator.ts'
 import { plugin } from './plugin/core.ts'
@@ -1903,6 +1904,18 @@ describe('command lifecycle hooks', () => {
           { strict: true, usageSilent: true, version: '1.0.0' }
         )
       ).resolves.toBe('1.0.0')
+
+      expect(mockCommand).not.toHaveBeenCalled()
+    })
+
+    test('reports help and version as unknown options without global plugin', async () => {
+      const mockCommand = vi.fn<() => void>()
+
+      for (const option of ['--help', '-h', '--version', '-v']) {
+        await expect(
+          boneCli([option], { run: mockCommand }, { strict: true, version: '1.0.0' })
+        ).rejects.toBeInstanceOf(AggregateError)
+      }
 
       expect(mockCommand).not.toHaveBeenCalled()
     })

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -1817,6 +1817,265 @@ describe('command lifecycle hooks', () => {
     expect(log()).toBe(`Optional argument '--id' is required`)
   })
 
+  describe('strict option validation', () => {
+    test('keeps unknown options compatible by default and with strict disabled', async () => {
+      const mockCommand = vi.fn<() => void>()
+
+      await cli(['--alow-reload'], { run: mockCommand })
+      await cli(['--alow-reload'], { run: mockCommand }, { strict: false })
+
+      expect(mockCommand).toHaveBeenCalledTimes(2)
+    })
+
+    test('reports unknown long options before command execution', async () => {
+      const utils = await import('./utils.ts')
+      const log = defineMockLog(utils)
+      const mockCommand = vi.fn<() => void>()
+
+      await expect(
+        cli(['--alow-reload'], { run: mockCommand }, { strict: true })
+      ).rejects.toBeInstanceOf(AggregateError)
+
+      expect(mockCommand).not.toHaveBeenCalled()
+      expect(log()).toBe('Unknown option: --alow-reload')
+    })
+
+    test('allows declared long, short, negatable, and kebab-case options', async () => {
+      const mockCommand = vi.fn<() => void>()
+
+      await cli(
+        ['--out-dir', 'dist', '-f', '--no-cache'],
+        {
+          toKebab: true,
+          args: {
+            outDir: {
+              type: 'string'
+            },
+            force: {
+              type: 'boolean',
+              short: 'f'
+            },
+            cache: {
+              type: 'boolean',
+              negatable: true
+            }
+          },
+          run: mockCommand
+        },
+        {
+          strict: true
+        }
+      )
+
+      expect(mockCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: {
+            outDir: 'dist',
+            force: true,
+            cache: false
+          }
+        })
+      )
+    })
+
+    test('ignores options after option terminator', async () => {
+      const mockCommand = vi.fn<() => void>()
+
+      await cli(['--', '--unknown'], { run: mockCommand }, { strict: true })
+
+      expect(mockCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rest: ['--unknown']
+        })
+      )
+    })
+
+    test('allows built-in help and version options', async () => {
+      const mockCommand = vi.fn<() => void>()
+
+      await expect(
+        cli(['--help'], { run: mockCommand }, { strict: true, usageSilent: true })
+      ).resolves.toBeTypeOf('string')
+      await expect(
+        cli(
+          ['--version'],
+          { run: mockCommand },
+          { strict: true, usageSilent: true, version: '1.0.0' }
+        )
+      ).resolves.toBe('1.0.0')
+
+      expect(mockCommand).not.toHaveBeenCalled()
+    })
+
+    test('allows custom global options from plugins', async () => {
+      const mockCommand = vi.fn<() => void>()
+      const globalConfig = plugin({
+        id: 'global-config',
+        setup: ctx => {
+          ctx.addGlobalOption('config', {
+            type: 'string',
+            short: 'c'
+          })
+        }
+      })
+
+      await cli(
+        ['--config', 'production'],
+        { run: mockCommand },
+        {
+          strict: true,
+          plugins: [globalConfig]
+        }
+      )
+
+      expect(mockCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: {
+            config: 'production'
+          }
+        })
+      )
+    })
+
+    test('uses resolved subcommand args', async () => {
+      const mockEntry = vi.fn<() => void>()
+      const mockDeploy = vi.fn<() => void>()
+
+      await cli(
+        ['deploy', '--env', 'production'],
+        { run: mockEntry },
+        {
+          strict: true,
+          subCommands: new Map([
+            [
+              'deploy',
+              define({
+                name: 'deploy',
+                args: {
+                  env: {
+                    type: 'string'
+                  }
+                },
+                run: mockDeploy
+              })
+            ]
+          ])
+        }
+      )
+
+      expect(mockEntry).not.toHaveBeenCalled()
+      expect(mockDeploy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: {
+            env: 'production'
+          }
+        })
+      )
+    })
+
+    test('uses resolved lazy command args', async () => {
+      const mockEntry = vi.fn<() => void>()
+      const mockLazy = vi.fn<() => void>()
+
+      await cli(
+        ['load', '--config', 'production'],
+        { run: mockEntry },
+        {
+          strict: true,
+          subCommands: new Map([
+            [
+              'load',
+              lazy(
+                () =>
+                  define({
+                    name: 'load',
+                    args: {
+                      config: {
+                        type: 'string'
+                      }
+                    },
+                    run: mockLazy
+                  }),
+                { name: 'load' }
+              )
+            ]
+          ])
+        }
+      )
+
+      expect(mockEntry).not.toHaveBeenCalled()
+      expect(mockLazy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: {
+            config: 'production'
+          }
+        })
+      )
+    })
+
+    test('merges unknown option errors with existing validation errors', async () => {
+      const utils = await import('./utils.ts')
+      const log = defineMockLog(utils)
+      const mockCommand = vi.fn<() => void>()
+      let capturedError: AggregateError | undefined
+
+      await expect(
+        cli(
+          ['--bad'],
+          {
+            args: {
+              id: {
+                type: 'string',
+                required: true
+              }
+            },
+            run: mockCommand
+          },
+          {
+            strict: true,
+            onErrorCommand: (_ctx, error) => {
+              capturedError = error as AggregateError
+            }
+          }
+        )
+      ).rejects.toBeInstanceOf(AggregateError)
+
+      expect(mockCommand).not.toHaveBeenCalled()
+      expect(capturedError?.errors.map((error: Error) => error.message)).toEqual([
+        `Optional argument '--id' is required`,
+        'Unknown option: --bad'
+      ])
+      expect(log()).toBe(`Optional argument '--id' is required\nUnknown option: --bad`)
+    })
+
+    test('localizes unknown option validation errors with i18n plugin', async () => {
+      const utils = await import('./utils.ts')
+      const log = defineMockLog(utils)
+      const mockCommand = vi.fn<() => void>()
+
+      await expect(
+        cli(
+          ['--alow-reload'],
+          { run: mockCommand },
+          {
+            strict: true,
+            plugins: [
+              i18n({
+                locale: 'ja-JP',
+                builtinResources: {
+                  'ja-JP': jsJPResource
+                }
+              })
+            ]
+          }
+        )
+      ).rejects.toBeInstanceOf(AggregateError)
+
+      expect(mockCommand).not.toHaveBeenCalled()
+      expect(log()).toBe('未定義のオプションです: --alow-reload')
+    })
+  })
+
   test('hooks with subcommands', async () => {
     const executionOrder: string[] = []
     const deployCommand = define({

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -273,6 +273,15 @@ function mergeValidationErrors(
   return new AggregateError(error ? [...error.errors, ...additionalErrors] : additionalErrors)
 }
 
+function hasUnknownOptionValidationError(error: AggregateError | undefined): boolean {
+  return (
+    error?.errors.some(
+      (error: unknown) =>
+        error instanceof ArgsValidationError && error.code === ArgsValidationErrorKeys.unknownOption
+    ) ?? false
+  )
+}
+
 const isObject = (val: unknown): val is Record<any, any> => val !== null && typeof val === 'object'
 
 function createInitialSubCommands<G extends GunshiParamsConstraint>(
@@ -557,7 +566,13 @@ async function executeCommand<G extends GunshiParamsConstraint = DefaultGunshiPa
   ctx: Readonly<CommandContext<G>>,
   decorators: Readonly<CommandDecorator<G>[]>
 ): Promise<string | undefined> {
-  const baseRunner = cmd.run || NOOP
+  const commandRunner = cmd.run || NOOP
+  const baseRunner: CommandRunner<G> = ctx => {
+    if (hasUnknownOptionValidationError(ctx.validationError)) {
+      throw ctx.validationError
+    }
+    return commandRunner(ctx)
+  }
 
   // apply plugin decorators
   const decoratedRunner = decorators.reduceRight(

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -187,8 +187,6 @@ type StrictOptionValidationOptions = {
 }
 
 const NEGATABLE_OPTION_PREFIX = 'no-'
-const IMPLICIT_ALLOWED_LONG_OPTIONS = new Set(['help', 'version'])
-const IMPLICIT_ALLOWED_SHORT_OPTIONS = new Set(['h', 'v'])
 
 function findUnknownOptions(
   args: Args,
@@ -228,17 +226,10 @@ function findUnknownOptions(
 
     const isLongOption = token.rawName.startsWith('--')
     if (isLongOption) {
-      if (
-        knownLongOptions.has(token.name) ||
-        knownNegatableOptions.has(token.name) ||
-        IMPLICIT_ALLOWED_LONG_OPTIONS.has(token.name)
-      ) {
+      if (knownLongOptions.has(token.name) || knownNegatableOptions.has(token.name)) {
         continue
       }
-    } else if (
-      knownShortOptions.has(token.name) ||
-      IMPLICIT_ALLOWED_SHORT_OPTIONS.has(token.name)
-    ) {
+    } else if (knownShortOptions.has(token.name)) {
       continue
     }
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -3,18 +3,26 @@
  * @license MIT
  */
 
-import { parseArgs, resolveArgs } from 'args-tokens'
+import { ArgsValidationError, ArgsValidationErrorKeys, parseArgs, resolveArgs } from 'args-tokens'
 import { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT, NOOP } from '../constants.ts'
 import { createCommandContext } from '../context.ts'
 import { createDecorators } from '../decorators.ts'
 import { createPluginContext } from '../plugin/context.ts'
 import { resolveDependencies } from '../plugin/dependency.ts'
-import { create, getCommandSubCommands, isLazyCommand, resolveLazyCommand } from '../utils.ts'
+import {
+  create,
+  getCommandSubCommands,
+  isLazyCommand,
+  kebabnize,
+  resolveLazyCommand
+} from '../utils.ts'
 
 import type { Decorators } from '../decorators.ts'
 import type { Plugin, PluginContext } from '../plugin.ts'
 import type {
   ArgToken,
+  Args,
+  ArgSchema,
   CliOptions,
   Command,
   CommandCallMode,
@@ -92,6 +100,16 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
     toKebab: resolvedCommand.toKebab,
     skipPositional
   })
+  const validationError = mergeValidationErrors(
+    error,
+    cliOptions.strict
+      ? createUnknownOptionErrors(
+          findUnknownOptions(args, tokens, {
+            toKebab: resolvedCommand.toKebab
+          })
+        )
+      : []
+  )
   const omitted = resolved.omitted
 
   const commandContext = await createCommandContext({
@@ -107,7 +125,7 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
     commandPath,
     command: resolvedCommand,
     extensions: getPluginExtensions(resolvedPlugins),
-    validationError: error,
+    validationError,
     cliOptions: cliOptions
   })
 
@@ -157,6 +175,111 @@ function resolveArguments<G extends GunshiParamsConstraint>(
     Object.fromEntries(pluginContext.globalOptions),
     args
   )
+}
+
+type UnknownOption = {
+  rawName: string
+  name: string
+}
+
+type StrictOptionValidationOptions = {
+  toKebab?: boolean
+}
+
+const NEGATABLE_OPTION_PREFIX = 'no-'
+const IMPLICIT_ALLOWED_LONG_OPTIONS = new Set(['help', 'version'])
+const IMPLICIT_ALLOWED_SHORT_OPTIONS = new Set(['h', 'v'])
+
+function findUnknownOptions(
+  args: Args,
+  tokens: ArgToken[],
+  options: StrictOptionValidationOptions
+): UnknownOption[] {
+  const knownLongOptions = new Set<string>()
+  const knownShortOptions = new Set<string>()
+  const knownNegatableOptions = new Set<string>()
+
+  for (const [name, schema] of Object.entries(args)) {
+    if (schema.type === 'positional') {
+      continue
+    }
+
+    const optionName = resolveOptionName(name, schema, options)
+    knownLongOptions.add(optionName)
+
+    if (schema.short) {
+      knownShortOptions.add(schema.short)
+    }
+
+    if (schema.type === 'boolean' && schema.negatable) {
+      knownNegatableOptions.add(`${NEGATABLE_OPTION_PREFIX}${optionName}`)
+    }
+  }
+
+  const unknownOptions: UnknownOption[] = []
+  for (const token of tokens) {
+    if (token.kind === 'option-terminator') {
+      break
+    }
+
+    if (token.kind !== 'option' || !token.name || !token.rawName) {
+      continue
+    }
+
+    const isLongOption = token.rawName.startsWith('--')
+    if (isLongOption) {
+      if (
+        knownLongOptions.has(token.name) ||
+        knownNegatableOptions.has(token.name) ||
+        IMPLICIT_ALLOWED_LONG_OPTIONS.has(token.name)
+      ) {
+        continue
+      }
+    } else if (
+      knownShortOptions.has(token.name) ||
+      IMPLICIT_ALLOWED_SHORT_OPTIONS.has(token.name)
+    ) {
+      continue
+    }
+
+    unknownOptions.push({
+      rawName: token.rawName,
+      name: token.name
+    })
+  }
+
+  return unknownOptions
+}
+
+function resolveOptionName(
+  name: string,
+  schema: ArgSchema,
+  options: StrictOptionValidationOptions
+): string {
+  return options.toKebab || schema.toKebab ? kebabnize(name) : name
+}
+
+function createUnknownOptionErrors(unknownOptions: UnknownOption[]): ArgsValidationError[] {
+  return unknownOptions.map(({ rawName, name }) => {
+    return new ArgsValidationError(`Unknown option: ${rawName}`, {
+      code: ArgsValidationErrorKeys.unknownOption,
+      values: {
+        rawName,
+        name
+      }
+    })
+  })
+}
+
+function mergeValidationErrors(
+  error: AggregateError | undefined,
+  additionalErrors: Error[]
+): AggregateError | undefined {
+  if (additionalErrors.length === 0) {
+    return error
+  }
+
+  return new AggregateError(error ? [...error.errors, ...additionalErrors] : additionalErrors)
 }
 
 const isObject = (val: unknown): val is Record<any, any> => val !== null && typeof val === 'object'

--- a/packages/gunshi/src/constants.ts
+++ b/packages/gunshi/src/constants.ts
@@ -23,6 +23,7 @@ export const CLI_OPTIONS_DEFAULT: CliOptions<DefaultGunshiParams> = {
   middleMargin: 10,
   usageOptionType: false,
   usageOptionValue: true,
+  strict: false,
   renderHeader: undefined,
   renderUsage: undefined,
   renderValidationErrors: undefined,

--- a/packages/gunshi/src/types.ts
+++ b/packages/gunshi/src/types.ts
@@ -216,6 +216,13 @@ export interface CommandEnvironment<G extends GunshiParamsConstraint = DefaultGu
    */
   usageSilent: boolean
   /**
+   * Whether to treat undefined options as argument validation errors.
+   *
+   * @default false
+   * @see {@linkcode CliOptions.strict}
+   */
+  strict: boolean
+  /**
    * Sub commands.
    *
    * @see {@linkcode CliOptions.subCommands}
@@ -308,6 +315,16 @@ export interface CliOptions<G extends GunshiParamsConstraint = DefaultGunshiPara
    * Whether to display the command usage.
    */
   usageSilent?: boolean
+  /**
+   * Whether to treat undefined options as argument validation errors.
+   *
+   * When enabled, option tokens that are not declared by the resolved command
+   * arguments or installed global options are reported as validation errors
+   * before the command runner is executed.
+   *
+   * @default false
+   */
+  strict?: boolean
   /**
    * Render function the command usage.
    */


### PR DESCRIPTION
Summary

This adds an opt-in `strict` CLI option that reports undefined options as argument validation errors instead of silently ignoring them. The check runs after args resolution, so command-local options, lazy commands, global plugin options, kebab-case names, negatable booleans, help/version flags, and `--` terminator behavior are preserved.

The change also adds Issue #611 regression coverage, verifies localized `err:arg:unknown-option` rendering through the i18n plugin, and documents the new strict validation mode.

Validation

`pnpm test:core`, `pnpm test:plugin-renderer`, `pnpm test:plugin-i18n`, `pnpm lint:typecheck`, `pnpm test`, `pnpm build`, and `pnpm lint` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI strict mode for option validation, including type support.
  * Unknown options are rejected before the command runs in strict mode (while `--` rest tokens remain unvalidated).
* **Bug Fixes**
  * Validation now surfaces consistent, localized unknown-option errors alongside existing argument errors, with correct aggregation and ordering.
  * Strict mode correctly handles built-in `--help/--version`, subcommands, and plugin-provided global options.
* **Documentation**
  * Documented strict unknown-option validation with examples and expected error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->