### PR TITLE
fix(cli): report command not found with context

### DIFF
--- a/packages/docs/src/guide/essentials/declarative.md
+++ b/packages/docs/src/guide/essentials/declarative.md
@@ -315,6 +315,36 @@ Unknown option: --alow-reload
 
 The error uses the `err:arg:unknown-option` resource key, so the message follows the same renderer and i18n behavior as other argument validation errors. Suggestions such as `Did you mean --allow-reload?` are intentionally left to suggestion plugins.
 
+#### Command Not Found Handling
+
+When a sub-command cannot be resolved, Gunshi reports it as a structured `CommandNotFoundError` inside the validation error pipeline. This avoids brittle checks such as `error.message.startsWith('Command not found:')`.
+
+```js
+import { CommandNotFoundError, cli, define, isCommandNotFoundError } from 'gunshi'
+
+try {
+  await cli(process.argv.slice(2), define({ name: 'app', run: () => {} }), {
+    subCommands: {
+      deploy: define({ name: 'deploy', run: () => {} })
+    }
+  })
+} catch (error) {
+  if (error instanceof AggregateError) {
+    const commandError = error.errors.find(isCommandNotFoundError)
+    if (commandError instanceof CommandNotFoundError) {
+      console.error(`Unknown command: ${commandError.commandName}`)
+      console.error(`Available commands: ${commandError.candidates.join(', ')}`)
+    }
+  }
+}
+```
+
+`commandName` is the command that could not be resolved. `candidates` contains command names from the same command level, which can be used by suggestion plugins. `commandPath` points to the parent command path. For example, `git remote ad` sets `commandName` to `ad` and `commandPath` to `['remote']`.
+
+The command context is created from the parent command, not the missing command. This means `ctx.command`, `ctx.name`, and `ctx.commandPath` describe the parent command. The actual missing command is available from `CommandNotFoundError.commandName`.
+
+The error uses the `err:cmd:not-found` resource key, so i18n plugins can localize the message while the fallback message remains compatible with `Command not found: <name>`.
+
 #### Kebab-Case Argument Names
 
 <!-- eslint-disable markdown/no-missing-label-refs -->

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -6,6 +6,7 @@ import { defineMockLog } from '../test/utils.ts'
 import { cli } from './cli.ts'
 import { cli as boneCli } from './cli/bone.ts'
 import { define, lazy } from './definition.ts'
+import { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from './error.ts'
 import { generate } from './generator.ts'
 import { plugin } from './plugin/core.ts'
 import { renderValidationErrors } from './renderer.ts'
@@ -292,6 +293,50 @@ describe('execute command', () => {
     await expect(async () => {
       await cli(['show'], { run: vi.fn<() => void>() }, { subCommands })
     }).rejects.toThrowError('Command not found: show')
+  })
+
+  test('command not found exposes structured metadata', async () => {
+    const mockEntry = vi.fn<() => void>()
+    const entry = define({
+      name: 'main',
+      run: mockEntry
+    })
+    const subCommands = new Map([
+      ['deploy', define({ name: 'deploy', run: vi.fn<() => void>() })],
+      ['init', define({ name: 'init', run: vi.fn<() => void>() })]
+    ])
+
+    let capturedError: AggregateError | undefined
+    await expect(
+      cli(['deply'], entry, {
+        subCommands,
+        onErrorCommand: (ctx, error) => {
+          capturedError = error as AggregateError
+          expect(ctx.name).toBe('main')
+          expect(ctx.commandPath).toEqual([])
+          expect(ctx.validationError).toBe(error)
+        }
+      })
+    ).rejects.toThrowError('Command not found: deply')
+
+    const commandError = findCommandNotFoundError(capturedError)
+    expect(commandError).toBeInstanceOf(CommandNotFoundError)
+    expect(commandError.code).toBe(CommandNotFoundErrorKeys.notFound)
+    expect(commandError.values).toEqual({ commandName: 'deply' })
+    expect(commandError.commandName).toBe('deply')
+    expect(commandError.commandPath).toEqual([])
+    expect(commandError.candidates).toEqual(['deploy', 'init', 'main'])
+    expect(mockEntry).not.toHaveBeenCalled()
+  })
+
+  test('command not found throws aggregate error without global plugin', async () => {
+    const entry = define({
+      name: 'main',
+      run: vi.fn<() => void>()
+    })
+    const subCommands = new Map([['deploy', define({ name: 'deploy', run: vi.fn<() => void>() })]])
+
+    await expect(boneCli(['deply'], entry, { subCommands })).rejects.toBeInstanceOf(AggregateError)
   })
 
   test('not registered entry in sub commands', async () => {
@@ -2087,6 +2132,41 @@ describe('command lifecycle hooks', () => {
       expect(mockCommand).not.toHaveBeenCalled()
       expect(log()).toBe('未定義のオプションです: --alow-reload')
     })
+
+    test('localizes command not found validation errors with i18n plugin', async () => {
+      const utils = await import('./utils.ts')
+      const log = defineMockLog(utils)
+      const mockCommand = vi.fn<() => void>()
+
+      await expect(
+        cli(
+          ['deply'],
+          define({
+            name: 'main',
+            run: mockCommand
+          }),
+          {
+            subCommands: {
+              deploy: define({
+                name: 'deploy',
+                run: vi.fn<() => void>()
+              })
+            },
+            plugins: [
+              i18n({
+                locale: 'ja-JP',
+                builtinResources: {
+                  'ja-JP': jsJPResource
+                }
+              })
+            ]
+          }
+        )
+      ).rejects.toBeInstanceOf(AggregateError)
+
+      expect(mockCommand).not.toHaveBeenCalled()
+      expect(log()).toBe('コマンドが見つかりません: deply')
+    })
   })
 
   test('hooks with subcommands', async () => {
@@ -2514,6 +2594,47 @@ describe('nested sub-commands', () => {
     )
   })
 
+  test('unknown nested sub-command reports parent command metadata', async () => {
+    const mockRemote = vi.fn<() => void>()
+
+    const remoteCommand = define({
+      name: 'remote',
+      description: 'Manage remotes',
+      subCommands: {
+        add: define({ name: 'add', run: vi.fn<() => void>() }),
+        remove: define({ name: 'remove', run: vi.fn<() => void>() })
+      },
+      run: mockRemote
+    })
+
+    let capturedError: AggregateError | undefined
+    await expect(
+      cli(
+        ['remote', 'ad'],
+        define({
+          name: 'git',
+          run: vi.fn<() => void>()
+        }),
+        {
+          name: 'git',
+          subCommands: { remote: remoteCommand },
+          onErrorCommand: (ctx, error) => {
+            capturedError = error as AggregateError
+            expect(ctx.name).toBe('remote')
+            expect(ctx.commandPath).toEqual(['remote'])
+            expect(ctx.validationError).toBe(error)
+          }
+        }
+      )
+    ).rejects.toThrowError('Command not found: ad')
+
+    const commandError = findCommandNotFoundError(capturedError)
+    expect(commandError.commandName).toBe('ad')
+    expect(commandError.commandPath).toEqual(['remote'])
+    expect(commandError.candidates).toEqual(['add', 'remove'])
+    expect(mockRemote).not.toHaveBeenCalled()
+  })
+
   test('commandPath is correct for depth=1', async () => {
     const mockCmd = vi.fn<() => void>()
 
@@ -2667,4 +2788,65 @@ describe('nested sub-commands', () => {
       })
     )
   })
+
+  test('unknown nested sub-command resolves lazy parent command context', async () => {
+    const mockRemote = vi.fn<() => void>()
+
+    const remoteCommand = lazy(
+      () =>
+        Promise.resolve(
+          define({
+            name: 'remote',
+            description: 'Manage remotes',
+            subCommands: {
+              add: define({ name: 'add', run: vi.fn<() => void>() }),
+              remove: define({ name: 'remove', run: vi.fn<() => void>() })
+            },
+            run: mockRemote
+          })
+        ),
+      {
+        name: 'remote',
+        description: 'Manage remotes',
+        subCommands: {
+          add: define({ name: 'add', run: vi.fn<() => void>() }),
+          remove: define({ name: 'remove', run: vi.fn<() => void>() })
+        }
+      }
+    )
+
+    let capturedError: AggregateError | undefined
+    await expect(
+      cli(
+        ['remote', 'ad'],
+        define({
+          name: 'git',
+          run: vi.fn<() => void>()
+        }),
+        {
+          name: 'git',
+          subCommands: { remote: remoteCommand },
+          onErrorCommand: (ctx, error) => {
+            capturedError = error as AggregateError
+            expect(ctx.name).toBe('remote')
+            expect(ctx.commandPath).toEqual(['remote'])
+            expect(ctx.validationError).toBe(error)
+          }
+        }
+      )
+    ).rejects.toThrowError('Command not found: ad')
+
+    const commandError = findCommandNotFoundError(capturedError)
+    expect(commandError.commandName).toBe('ad')
+    expect(commandError.commandPath).toEqual(['remote'])
+    expect(commandError.candidates).toEqual(['add', 'remove'])
+    expect(mockRemote).not.toHaveBeenCalled()
+  })
 })
+
+function findCommandNotFoundError(error: AggregateError | undefined): CommandNotFoundError {
+  expect(error).toBeInstanceOf(AggregateError)
+  const commandError = error?.errors.find((error: unknown) => isCommandNotFoundError(error))
+  expect(commandError).toBeInstanceOf(CommandNotFoundError)
+  return commandError as CommandNotFoundError
+}

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -308,7 +308,7 @@ describe('execute command', () => {
 
     let capturedError: AggregateError | undefined
     await expect(
-      cli(['deply'], entry, {
+      cli(['missing'], entry, {
         subCommands,
         onErrorCommand: (ctx, error) => {
           capturedError = error as AggregateError
@@ -317,13 +317,13 @@ describe('execute command', () => {
           expect(ctx.validationError).toBe(error)
         }
       })
-    ).rejects.toThrowError('Command not found: deply')
+    ).rejects.toThrowError('Command not found: missing')
 
     const commandError = findCommandNotFoundError(capturedError)
     expect(commandError).toBeInstanceOf(CommandNotFoundError)
     expect(commandError.code).toBe(CommandNotFoundErrorKeys.notFound)
-    expect(commandError.values).toEqual({ commandName: 'deply' })
-    expect(commandError.commandName).toBe('deply')
+    expect(commandError.values).toEqual({ commandName: 'missing' })
+    expect(commandError.commandName).toBe('missing')
     expect(commandError.commandPath).toEqual([])
     expect(commandError.candidates).toEqual(['deploy', 'init', 'main'])
     expect(mockEntry).not.toHaveBeenCalled()
@@ -336,7 +336,9 @@ describe('execute command', () => {
     })
     const subCommands = new Map([['deploy', define({ name: 'deploy', run: vi.fn<() => void>() })]])
 
-    await expect(boneCli(['deply'], entry, { subCommands })).rejects.toBeInstanceOf(AggregateError)
+    await expect(boneCli(['missing'], entry, { subCommands })).rejects.toBeInstanceOf(
+      AggregateError
+    )
   })
 
   test('not registered entry in sub commands', async () => {
@@ -2140,7 +2142,7 @@ describe('command lifecycle hooks', () => {
 
       await expect(
         cli(
-          ['deply'],
+          ['missing'],
           define({
             name: 'main',
             run: mockCommand
@@ -2165,7 +2167,7 @@ describe('command lifecycle hooks', () => {
       ).rejects.toBeInstanceOf(AggregateError)
 
       expect(mockCommand).not.toHaveBeenCalled()
-      expect(log()).toBe('コマンドが見つかりません: deply')
+      expect(log()).toBe('コマンドが見つかりません: missing')
     })
   })
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -7,7 +7,11 @@ import { ArgsValidationError, ArgsValidationErrorKeys, parseArgs, resolveArgs } 
 import { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT, NOOP } from '../constants.ts'
 import { createCommandContext } from '../context.ts'
 import { createDecorators } from '../decorators.ts'
-import { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from '../error.ts'
+import {
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys,
+  hasPriorityValidationError
+} from '../error.ts'
 import { createPluginContext } from '../plugin/context.ts'
 import { resolveDependencies } from '../plugin/dependency.ts'
 import {
@@ -294,17 +298,6 @@ function mergeValidationErrors(
   return new AggregateError(
     error ? [...error.errors, ...additionalErrors] : additionalErrors,
     error?.message || additionalErrors[0]?.message
-  )
-}
-
-function hasPriorityValidationError(error: AggregateError | undefined): boolean {
-  return (
-    error?.errors.some(
-      (error: unknown) =>
-        isCommandNotFoundError(error) ||
-        (error instanceof ArgsValidationError &&
-          error.code === ArgsValidationErrorKeys.unknownOption)
-    ) ?? false
   )
 }
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -7,6 +7,7 @@ import { ArgsValidationError, ArgsValidationErrorKeys, parseArgs, resolveArgs } 
 import { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT, NOOP } from '../constants.ts'
 import { createCommandContext } from '../context.ts'
 import { createDecorators } from '../decorators.ts'
+import { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from '../error.ts'
 import { createPluginContext } from '../plugin/context.ts'
 import { resolveDependencies } from '../plugin/dependency.ts'
 import {
@@ -75,42 +76,62 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
 
   const resolved = resolveCommandTree(tokens, entry, cliOptions)
   const { commandName: name, command, callMode, commandPath, depth, levelSubCommands } = resolved
-  if (!command) {
-    throw new Error(`Command not found: ${name || ''}`)
+
+  let targetCommand = command
+  let targetCommandName = name
+  let targetCallMode = callMode
+  let targetCommandPath = commandPath
+  let targetDepth = depth
+  let targetOmitted = resolved.omitted
+  let targetLevelSubCommands = levelSubCommands
+  const additionalValidationErrors: Error[] = []
+
+  if (!targetCommand) {
+    if (!resolved.parentCommand || !resolved.unresolvedCommandName) {
+      throw new Error(`Command not found: ${name || ''}`)
+    }
+
+    targetCommand = resolved.parentCommand
+    targetCommandName = resolved.parentCommandName
+    targetCommandPath = resolved.parentCommandPath || []
+    targetDepth = targetCommandPath.length
+    targetCallMode = targetDepth > 0 ? 'subCommand' : 'entry'
+    targetOmitted = false
+    targetLevelSubCommands = resolved.parentSubCommands
+    additionalValidationErrors.push(createCommandNotFoundError(resolved))
   }
 
   // override subCommands with level-specific sub-commands for rendering
-  if (levelSubCommands) {
-    cliOptions.subCommands = levelSubCommands
+  if (targetLevelSubCommands) {
+    cliOptions.subCommands = targetLevelSubCommands
   }
 
   // resolve lazy commands before parsing so loader-defined args are available
-  const resolvedCommand = isLazyCommand<G>(command)
-    ? await resolveLazyCommand<G>(command, name, true)
-    : command
+  const resolvedCommand = isLazyCommand<G>(targetCommand)
+    ? await resolveLazyCommand<G>(targetCommand, targetCommandName, true)
+    : targetCommand
 
   const args = resolveArguments(pluginContext, getCommandArgs(resolvedCommand))
 
   // skipPositional: how many leading positionals to skip (they're consumed as command names)
   // depth=0 → -1 (no skip), depth=1 → 0 (skip 1, existing behavior), depth=2 → 1 (skip 2), etc.
-  const skipPositional = depth > 0 ? depth - 1 : -1
+  const skipPositional = targetDepth > 0 ? targetDepth - 1 : -1
 
   const { explicit, values, positionals, rest, error } = resolveArgs(args, tokens, {
     shortGrouping: true,
     toKebab: resolvedCommand.toKebab,
     skipPositional
   })
-  const validationError = mergeValidationErrors(
-    error,
-    cliOptions.strict
+  const validationError = mergeValidationErrors(error, [
+    ...additionalValidationErrors,
+    ...(cliOptions.strict
       ? createUnknownOptionErrors(
           findUnknownOptions(args, tokens, {
             toKebab: resolvedCommand.toKebab
           })
         )
-      : []
-  )
-  const omitted = resolved.omitted
+      : [])
+  ])
 
   const commandContext = await createCommandContext({
     args,
@@ -120,9 +141,9 @@ export async function cliCore<G extends GunshiParamsConstraint = DefaultGunshiPa
     rest,
     argv,
     tokens,
-    omitted,
-    callMode,
-    commandPath,
+    omitted: targetOmitted,
+    callMode: targetCallMode,
+    commandPath: targetCommandPath,
     command: resolvedCommand,
     extensions: getPluginExtensions(resolvedPlugins),
     validationError,
@@ -270,14 +291,19 @@ function mergeValidationErrors(
     return error
   }
 
-  return new AggregateError(error ? [...error.errors, ...additionalErrors] : additionalErrors)
+  return new AggregateError(
+    error ? [...error.errors, ...additionalErrors] : additionalErrors,
+    error?.message || additionalErrors[0]?.message
+  )
 }
 
-function hasUnknownOptionValidationError(error: AggregateError | undefined): boolean {
+function hasPriorityValidationError(error: AggregateError | undefined): boolean {
   return (
     error?.errors.some(
       (error: unknown) =>
-        error instanceof ArgsValidationError && error.code === ArgsValidationErrorKeys.unknownOption
+        isCommandNotFoundError(error) ||
+        (error instanceof ArgsValidationError &&
+          error.code === ArgsValidationErrorKeys.unknownOption)
     ) ?? false
   )
 }
@@ -378,6 +404,11 @@ type ResolveCommandContext<G extends GunshiParamsConstraint = DefaultGunshiParam
   depth: number
   omitted: boolean
   levelSubCommands: Map<string, Command<G> | LazyCommand<G>> | undefined
+  unresolvedCommandName?: string | undefined
+  parentCommand?: Command<G> | LazyCommand<G> | undefined
+  parentCommandName?: string | undefined
+  parentCommandPath?: string[] | undefined
+  parentSubCommands?: Map<string, Command<G> | LazyCommand<G>> | undefined
 }
 
 function resolveCommandTree<G extends GunshiParamsConstraint>(
@@ -455,17 +486,34 @@ function resolveCommandTree<G extends GunshiParamsConstraint>(
         if (options.fallbackToEntry) {
           return resolveAsEntry()
         }
+        const parent = resolveAsEntry()
         return {
           commandName: token,
           callMode: 'unexpected',
           commandPath: [],
           depth: 0,
           omitted: false,
-          levelSubCommands: undefined
+          levelSubCommands: undefined,
+          unresolvedCommandName: token,
+          parentCommand: parent.command,
+          parentCommandName: parent.commandName,
+          parentCommandPath: [],
+          parentSubCommands: options.subCommands
         }
       }
-      // depth > 0: stop exploring, remaining tokens are positional args
-      break
+      return {
+        commandName: token,
+        callMode: 'unexpected',
+        commandPath: [...commandPath],
+        depth,
+        omitted: false,
+        levelSubCommands: undefined,
+        unresolvedCommandName: token,
+        parentCommand: resolvedCommand,
+        parentCommandName: resolvedName,
+        parentCommandPath: [...commandPath],
+        parentSubCommands: currentSubCommands
+      }
     }
 
     // resolve command name if missing - shallow copy to avoid mutating user objects
@@ -536,6 +584,21 @@ function resolveCommandTree<G extends GunshiParamsConstraint>(
   }
 }
 
+function createCommandNotFoundError<G extends GunshiParamsConstraint>(
+  resolved: ResolveCommandContext<G>
+): CommandNotFoundError {
+  const commandName = resolved.unresolvedCommandName || resolved.commandName || ''
+  return new CommandNotFoundError(`Command not found: ${commandName}`, {
+    code: CommandNotFoundErrorKeys.notFound,
+    values: {
+      commandName
+    },
+    commandName,
+    candidates: [...(resolved.parentSubCommands?.keys() || [])],
+    commandPath: resolved.parentCommandPath || []
+  })
+}
+
 function resolveEntryName<G extends GunshiParamsConstraint>(
   entry: Command<G> | LazyCommand<G>
 ): string {
@@ -568,7 +631,7 @@ async function executeCommand<G extends GunshiParamsConstraint = DefaultGunshiPa
 ): Promise<string | undefined> {
   const commandRunner = cmd.run || NOOP
   const baseRunner: CommandRunner<G> = ctx => {
-    if (hasUnknownOptionValidationError(ctx.validationError)) {
+    if (hasPriorityValidationError(ctx.validationError)) {
       throw ctx.validationError
     }
     return commandRunner(ctx)

--- a/packages/gunshi/src/error.ts
+++ b/packages/gunshi/src/error.ts
@@ -1,0 +1,84 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+/**
+ * Command not found error resource keys.
+ */
+export const CommandNotFoundErrorKeys = {
+  notFound: 'err:cmd:not-found'
+} as const
+
+/**
+ * Command not found error code.
+ */
+export type CommandNotFoundErrorCode =
+  (typeof CommandNotFoundErrorKeys)[keyof typeof CommandNotFoundErrorKeys]
+
+/**
+ * Options for {@link CommandNotFoundError}.
+ */
+export type CommandNotFoundErrorOptions = {
+  /**
+   * Localization resource key for command-not-found rendering.
+   */
+  code?: CommandNotFoundErrorCode
+  /**
+   * Values used when localizing the message.
+   */
+  values?: Record<string, unknown>
+  /**
+   * The command name that could not be resolved.
+   */
+  commandName: string
+  /**
+   * Command names available at the same level.
+   */
+  candidates?: readonly string[]
+  /**
+   * Parent command path where resolution failed.
+   */
+  commandPath?: readonly string[]
+  /**
+   * Underlying cause.
+   */
+  cause?: unknown
+}
+
+/**
+ * Error raised when a command cannot be resolved.
+ */
+export class CommandNotFoundError extends Error {
+  readonly code?: CommandNotFoundErrorCode
+  readonly values: Record<string, unknown>
+  readonly commandName: string
+  readonly candidates: readonly string[]
+  readonly commandPath: readonly string[]
+
+  /**
+   * Create a command-not-found error.
+   *
+   * @param message - Fallback error message
+   * @param options - Command-not-found metadata
+   */
+  constructor(message: string, options: CommandNotFoundErrorOptions) {
+    super(message, { cause: options.cause })
+    this.name = 'CommandNotFoundError'
+    this.code = options.code
+    this.values = options.values || {}
+    this.commandName = options.commandName
+    this.candidates = options.candidates || []
+    this.commandPath = options.commandPath || []
+  }
+}
+
+/**
+ * Check whether an error is a {@link CommandNotFoundError}.
+ *
+ * @param error - An unknown error
+ * @returns `true` if the error is a {@link CommandNotFoundError}
+ */
+export function isCommandNotFoundError(error: unknown): error is CommandNotFoundError {
+  return error instanceof CommandNotFoundError
+}

--- a/packages/gunshi/src/error.ts
+++ b/packages/gunshi/src/error.ts
@@ -3,6 +3,8 @@
  * @license MIT
  */
 
+import { ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
+
 /**
  * Command not found error resource keys.
  */
@@ -81,4 +83,20 @@ export class CommandNotFoundError extends Error {
  */
 export function isCommandNotFoundError(error: unknown): error is CommandNotFoundError {
   return error instanceof CommandNotFoundError
+}
+
+/**
+ * Check whether validation errors should be handled before version, help, or command execution.
+ *
+ * @param error - An aggregate validation error
+ * @returns `true` if the validation error must be handled with priority
+ */
+export function hasPriorityValidationError(error: AggregateError | undefined): boolean {
+  return (
+    error?.errors.some(
+      (error: unknown) =>
+        isCommandNotFoundError(error) ||
+        (isArgsValidationError(error) && error.code === ArgsValidationErrorKeys.unknownOption)
+    ) ?? false
+  )
 }

--- a/packages/gunshi/src/index.test-d.ts
+++ b/packages/gunshi/src/index.test-d.ts
@@ -1,7 +1,14 @@
 import { expectTypeOf, test } from 'vitest'
-import { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from './index.ts'
+import {
+  ArgsValidationError,
+  ArgsValidationErrorKeys,
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys,
+  isArgsValidationError,
+  isCommandNotFoundError
+} from './index.ts'
 
-import type { ArgsValidationErrorCode } from './index.ts'
+import type { ArgsValidationErrorCode, CommandNotFoundErrorCode } from './index.ts'
 
 test('exports args validation error types', () => {
   expectTypeOf(ArgsValidationError).toBeConstructibleWith('fallback message')
@@ -10,4 +17,15 @@ test('exports args validation error types', () => {
     (typeof ArgsValidationErrorKeys)[keyof typeof ArgsValidationErrorKeys]
   >()
   expectTypeOf(isArgsValidationError).toBeFunction()
+})
+
+test('exports command not found error types', () => {
+  expectTypeOf(CommandNotFoundError).toBeConstructibleWith('Command not found: deployx', {
+    commandName: 'deployx'
+  })
+  expectTypeOf(CommandNotFoundErrorKeys.notFound).toEqualTypeOf<'err:cmd:not-found'>()
+  expectTypeOf<CommandNotFoundErrorCode>().toEqualTypeOf<
+    (typeof CommandNotFoundErrorKeys)[keyof typeof CommandNotFoundErrorKeys]
+  >()
+  expectTypeOf(isCommandNotFoundError).toBeFunction()
 })

--- a/packages/gunshi/src/index.test.ts
+++ b/packages/gunshi/src/index.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from 'vitest'
-import { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from './index.ts'
+import {
+  ArgsValidationError,
+  ArgsValidationErrorKeys,
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys,
+  isArgsValidationError,
+  isCommandNotFoundError
+} from './index.ts'
 
 test('exports args validation error runtime API', () => {
   const error = new ArgsValidationError('fallback message', {
@@ -13,5 +20,25 @@ test('exports args validation error runtime API', () => {
   expect(error.code).toBe(ArgsValidationErrorKeys.requiredOption)
   expect(error.values).toEqual({
     displayName: "'--id'"
+  })
+})
+
+test('exports command not found error runtime API', () => {
+  const error = new CommandNotFoundError('Command not found: deployx', {
+    code: CommandNotFoundErrorKeys.notFound,
+    values: {
+      commandName: 'deployx'
+    },
+    commandName: 'deployx',
+    candidates: ['deploy'],
+    commandPath: []
+  })
+
+  expect(isCommandNotFoundError(error)).toBe(true)
+  expect(error.code).toBe(CommandNotFoundErrorKeys.notFound)
+  expect(error.commandName).toBe('deployx')
+  expect(error.candidates).toEqual(['deploy'])
+  expect(error.values).toEqual({
+    commandName: 'deployx'
   })
 })

--- a/packages/gunshi/src/index.ts
+++ b/packages/gunshi/src/index.ts
@@ -10,7 +10,7 @@
  * - `plugin`: A function to create a plugin.
  * - `createCommandContext`: A function to create a command context, mainly for testing purposes.
  * - `args-tokens` utilities: `parseArgs`, `resolveArgs`, `ArgsValidationError`, `ArgsValidationErrorKeys`, `ArgsValidationErrorCode`, and `isArgsValidationError` for parsing and validating command line arguments.
- * - Structured error utilities: `CommandNotFoundError`, `CommandNotFoundErrorKeys`, `CommandNotFoundErrorCode`, and `isCommandNotFoundError`.
+ * - Structured error utilities: `CommandNotFoundError`, `CommandNotFoundErrorKeys`, `CommandNotFoundErrorCode`, `CommandNotFoundErrorOptions`, `isCommandNotFoundError`, and `hasPriorityValidationError`.
  * - Some basic type definitions, such as `CommandContext`, `Plugin`, `PluginContext`, etc.
  *
  * @example
@@ -38,7 +38,12 @@ export * from './cli.ts'
 export { ANONYMOUS_COMMAND_NAME } from './constants.ts'
 export { createCommandContext } from './context.ts'
 export { define, defineWithTypes, lazy, lazyWithTypes } from './definition.ts'
-export { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from './error.ts'
+export {
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys,
+  hasPriorityValidationError,
+  isCommandNotFoundError
+} from './error.ts'
 export { plugin } from './plugin/core.ts'
 
 export type { CommandContextParams } from './context.ts'

--- a/packages/gunshi/src/index.ts
+++ b/packages/gunshi/src/index.ts
@@ -10,6 +10,7 @@
  * - `plugin`: A function to create a plugin.
  * - `createCommandContext`: A function to create a command context, mainly for testing purposes.
  * - `args-tokens` utilities: `parseArgs`, `resolveArgs`, `ArgsValidationError`, `ArgsValidationErrorKeys`, `ArgsValidationErrorCode`, and `isArgsValidationError` for parsing and validating command line arguments.
+ * - Structured error utilities: `CommandNotFoundError`, `CommandNotFoundErrorKeys`, `CommandNotFoundErrorCode`, and `isCommandNotFoundError`.
  * - Some basic type definitions, such as `CommandContext`, `Plugin`, `PluginContext`, etc.
  *
  * @example
@@ -37,9 +38,11 @@ export * from './cli.ts'
 export { ANONYMOUS_COMMAND_NAME } from './constants.ts'
 export { createCommandContext } from './context.ts'
 export { define, defineWithTypes, lazy, lazyWithTypes } from './definition.ts'
+export { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from './error.ts'
 export { plugin } from './plugin/core.ts'
 
 export type { CommandContextParams } from './context.ts'
+export type { CommandNotFoundErrorCode, CommandNotFoundErrorOptions } from './error.ts'
 export type { ArgsValidationErrorCode } from 'args-tokens'
 export type { PluginContext } from './plugin/context.ts'
 export type {

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -25,7 +25,12 @@
 
 export { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT } from './constants.ts'
 export { createCommandContext } from './context.ts'
-export { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from './error.ts'
+export {
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys,
+  hasPriorityValidationError,
+  isCommandNotFoundError
+} from './error.ts'
 export { plugin } from './plugin/core.ts'
 export { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
 

--- a/packages/gunshi/src/plugin.ts
+++ b/packages/gunshi/src/plugin.ts
@@ -25,10 +25,12 @@
 
 export { ANONYMOUS_COMMAND_NAME, CLI_OPTIONS_DEFAULT } from './constants.ts'
 export { createCommandContext } from './context.ts'
+export { CommandNotFoundError, CommandNotFoundErrorKeys, isCommandNotFoundError } from './error.ts'
 export { plugin } from './plugin/core.ts'
 export { ArgsValidationError, ArgsValidationErrorKeys, isArgsValidationError } from 'args-tokens'
 
 export type { CommandContextParams } from './context.ts'
+export type { CommandNotFoundErrorCode, CommandNotFoundErrorOptions } from './error.ts'
 export type { ArgsValidationErrorCode } from 'args-tokens'
 export type { PluginContext } from './plugin/context.ts'
 export type {

--- a/packages/plugin-global/src/decorator.ts
+++ b/packages/plugin-global/src/decorator.ts
@@ -5,11 +5,7 @@
 
 import { pluginId as Global } from './types.ts'
 
-import {
-  ArgsValidationErrorKeys,
-  isArgsValidationError,
-  isCommandNotFoundError
-} from '@gunshi/plugin'
+import { hasPriorityValidationError } from '@gunshi/plugin'
 
 import type { CommandDecorator, DefaultGunshiParams } from '@gunshi/plugin'
 import type { GlobalExtension } from './extension.ts'
@@ -65,16 +61,6 @@ const decorator: CommandDecorator<{
 
   // normal command execution
   return baseRunner(ctx)
-}
-
-function hasPriorityValidationError(error: AggregateError | undefined): boolean {
-  return (
-    error?.errors.some(
-      (error: unknown) =>
-        isCommandNotFoundError(error) ||
-        (isArgsValidationError(error) && error.code === ArgsValidationErrorKeys.unknownOption)
-    ) ?? false
-  )
 }
 
 export default decorator

--- a/packages/plugin-global/src/decorator.ts
+++ b/packages/plugin-global/src/decorator.ts
@@ -5,6 +5,12 @@
 
 import { pluginId as Global } from './types.ts'
 
+import {
+  ArgsValidationErrorKeys,
+  isArgsValidationError,
+  isCommandNotFoundError
+} from '@gunshi/plugin'
+
 import type { CommandDecorator, DefaultGunshiParams } from '@gunshi/plugin'
 import type { GlobalExtension } from './extension.ts'
 import type { PluginId } from './types.ts'
@@ -26,6 +32,11 @@ const decorator: CommandDecorator<{
       [Global]: { showVersion, showHeader, showUsage, showValidationErrors }
     }
   } = ctx
+
+  if (hasPriorityValidationError(validationError)) {
+    await showValidationErrors(validationError!)
+    throw validationError
+  }
 
   if (values.version) {
     return showVersion()
@@ -54,6 +65,16 @@ const decorator: CommandDecorator<{
 
   // normal command execution
   return baseRunner(ctx)
+}
+
+function hasPriorityValidationError(error: AggregateError | undefined): boolean {
+  return (
+    error?.errors.some(
+      (error: unknown) =>
+        isCommandNotFoundError(error) ||
+        (isArgsValidationError(error) && error.code === ArgsValidationErrorKeys.unknownOption)
+    ) ?? false
+  )
 }
 
 export default decorator

--- a/packages/plugin-renderer/src/validation.test.ts
+++ b/packages/plugin-renderer/src/validation.test.ts
@@ -1,5 +1,10 @@
 import i18n from '@gunshi/plugin-i18n'
-import { ArgsValidationError, ArgsValidationErrorKeys } from '@gunshi/plugin'
+import {
+  ArgsValidationError,
+  ArgsValidationErrorKeys,
+  CommandNotFoundError,
+  CommandNotFoundErrorKeys
+} from '@gunshi/plugin'
 import { expect, test } from 'vitest'
 import { createCommandContext } from '../../gunshi/src/context.ts'
 import renderer from './index.ts'
@@ -65,6 +70,63 @@ test('args validation error falls back to message for unknown code', async () =>
   ])
 
   await expect(renderValidationErrors(ctx, error)).resolves.toEqual('fallback message')
+})
+
+test('command not found error keeps fallback message without i18n', async () => {
+  const ctx = await createCommandContext({
+    cliOptions: {
+      cwd: '/path/to/cmd1',
+      version: '0.0.0',
+      name: 'cmd1'
+    }
+  })
+  const error = new AggregateError([
+    new CommandNotFoundError('Command not found: deployx', {
+      code: CommandNotFoundErrorKeys.notFound,
+      values: {
+        commandName: 'deployx'
+      },
+      commandName: 'deployx',
+      candidates: ['deploy']
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual('Command not found: deployx')
+})
+
+test('command not found error uses i18n resource', async () => {
+  const i18nPlugin = i18n({
+    locale: 'ja-JP',
+    builtinResources: {
+      'ja-JP': {
+        'err:cmd:not-found': '不明なコマンド: {$commandName}'
+      }
+    }
+  })
+  const rendererPlugin = renderer()
+  const command = {
+    name: 'test',
+    run: async () => {}
+  } as Command
+  const ctx = await createCommandContext({
+    command,
+    extensions: {
+      [i18nPlugin.id]: i18nPlugin.extension,
+      [rendererPlugin.id]: rendererPlugin.extension
+    }
+  })
+  const error = new AggregateError([
+    new CommandNotFoundError('Command not found: deployx', {
+      code: CommandNotFoundErrorKeys.notFound,
+      values: {
+        commandName: 'deployx'
+      },
+      commandName: 'deployx',
+      candidates: ['deploy']
+    })
+  ])
+
+  await expect(renderValidationErrors(ctx, error)).resolves.toEqual('不明なコマンド: deployx')
 })
 
 test('args validation error uses i18n resource', async () => {

--- a/packages/plugin-renderer/src/validation.ts
+++ b/packages/plugin-renderer/src/validation.ts
@@ -3,7 +3,11 @@
  * @license MIT
  */
 
-import { ArgsValidationErrorKeys, isArgsValidationError } from '@gunshi/plugin'
+import {
+  ArgsValidationErrorKeys,
+  isArgsValidationError,
+  isCommandNotFoundError
+} from '@gunshi/plugin'
 import { namespacedId, resolveKey } from '@gunshi/shared'
 
 import type {
@@ -37,6 +41,13 @@ async function renderValidationError<G extends GunshiParams = DefaultGunshiParam
   ctx: CommandContext<G>,
   error: Error
 ): Promise<string> {
+  if (isCommandNotFoundError(error) && error.code) {
+    const message = await localize(ctx, error.code, error.values)
+    if (message && message !== error.code) {
+      return message
+    }
+  }
+
   if (isArgsValidationError(error) && error.code) {
     const values = await resolveValidationValues(ctx, error)
     const message = await localize(ctx, error.code, values)

--- a/packages/resources/locales/en-US.json
+++ b/packages/resources/locales/en-US.json
@@ -17,5 +17,6 @@
   "err:arg:invalid-type": "Invalid value for {$displayName}: expected {$expected}",
   "err:arg:invalid-choice": "Invalid value for {$displayName}: expected one of {$choices}",
   "err:arg:custom-parse": "Invalid value for {$displayName}: {$reason}",
-  "err:arg:unknown-option": "Unknown option: {$rawName}"
+  "err:arg:unknown-option": "Unknown option: {$rawName}",
+  "err:cmd:not-found": "Command not found: {$commandName}"
 }

--- a/packages/resources/locales/ja-JP.json
+++ b/packages/resources/locales/ja-JP.json
@@ -17,5 +17,6 @@
   "err:arg:invalid-type": "{$displayName} の値が不正です。期待される型: {$expected}",
   "err:arg:invalid-choice": "{$displayName} の値が不正です。指定可能な値: {$choices}",
   "err:arg:custom-parse": "{$displayName} の値が不正です: {$reason}",
-  "err:arg:unknown-option": "未定義のオプションです: {$rawName}"
+  "err:arg:unknown-option": "未定義のオプションです: {$rawName}",
+  "err:cmd:not-found": "コマンドが見つかりません: {$commandName}"
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -69,3 +69,5 @@ export const ARG_ERROR_RESOURCE_KEYS = [
   'err:arg:custom-parse',
   'err:arg:unknown-option'
 ] as const
+
+export const COMMAND_ERROR_RESOURCE_KEYS = ['err:cmd:not-found'] as const

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -8,6 +8,7 @@ import {
   ARG_PREFIX,
   BUILT_IN_KEY_SEPARATOR,
   BUILT_IN_PREFIX,
+  COMMAND_ERROR_RESOURCE_KEYS,
   COMMAND_BUILTIN_RESOURCE_KEYS,
   COMMON_ARGS
 } from './constants.ts'
@@ -73,10 +74,16 @@ export type CommandBuiltinResourceKeys = (typeof COMMAND_BUILTIN_RESOURCE_KEYS)[
 export type ArgErrorResourceKeys = (typeof ARG_ERROR_RESOURCE_KEYS)[number]
 
 /**
+ * Command validation error resource keys.
+ */
+export type CommandErrorResourceKeys = (typeof COMMAND_ERROR_RESOURCE_KEYS)[number]
+
+/**
  * Built-in resource keys.
  */
 export type BuiltinResourceKeys =
   | ArgErrorResourceKeys
+  | CommandErrorResourceKeys
   | CommandBuiltinArgsKeys
   | CommandBuiltinResourceKeys
 


### PR DESCRIPTION
## Summary

related #250 

This fixes command resolution for unknown commands by creating a structured CommandNotFoundError after the CLI context has been resolved. The error now carries the missing command name, same-level candidates, and parent command path so renderer and plugin hooks can handle it consistently.

The renderer and bundled resources now support err:cmd:not-found localization, while global option handling preserves priority validation behavior before help/version rendering. Tests cover top-level, nested, lazy, bone, and i18n flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured “command not found” errors, including error metadata (command name, path, candidates) and localized messaging support.
  * Exposed new public error utilities to detect and prioritize these errors during validation.

* **Bug Fixes**
  * Unknown (nested) subcommands now report the correct parent command context.
  * Validation handling now aggregates strict-parse issues with command-not-found details and ensures the right handler path is used.

* **Documentation**
  * Updated the essentials guide with a new subsection and example detection code for command-not-found handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->