### PR TITLE
feat: add Levenshtein suggestion plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build:plugin:global": "pnpm -F @gunshi/plugin-global build",
     "build:plugin:i18n": "pnpm -F @gunshi/plugin-i18n build",
     "build:plugin:renderer": "pnpm -F @gunshi/plugin-renderer build",
+    "build:plugin:suggestion": "pnpm -F @gunshi/plugin-suggestion build",
     "build:resources": "pnpm -F @gunshi/resources build",
     "build:shared": "pnpm -F @gunshi/shared build",
     "changelog": "gh-changelogen --repo=kazupon/gunshi",
@@ -84,6 +85,7 @@
     "test:plugin-global": "vitest --typecheck run packages/plugin-global",
     "test:plugin-i18n": "vitest --typecheck run packages/plugin-i18n",
     "test:plugin-renderer": "vitest --typecheck run packages/plugin-renderer",
+    "test:plugin-suggestion": "vitest --typecheck run packages/plugin-suggestion",
     "typecheck:deno": "pnpm -r --if-present typecheck:deno"
   },
   "devDependencies": {

--- a/packages/docs/src/guide/essentials/plugin-system.md
+++ b/packages/docs/src/guide/essentials/plugin-system.md
@@ -204,6 +204,84 @@ Key benefits:
 
 <!-- eslint-enable markdown/no-missing-label-refs -->
 
+### Suggestions
+
+Add correction hints for unknown long options and unknown commands with the suggestion plugin:
+
+::: code-group
+
+```sh [npm]
+npm install --save @gunshi/plugin-suggestion
+```
+
+```sh [pnpm]
+pnpm add @gunshi/plugin-suggestion
+```
+
+```sh [yarn]
+yarn add @gunshi/plugin-suggestion
+```
+
+```sh [deno]
+deno add jsr:@gunshi/plugin-suggestion
+```
+
+```sh [bun]
+bun add @gunshi/plugin-suggestion
+```
+
+:::
+
+```js
+import { cli, define } from 'gunshi'
+import { suggestion } from '@gunshi/plugin-suggestion'
+
+const command = define({
+  name: 'app',
+  toKebab: true,
+  args: {
+    allowReload: {
+      type: 'boolean',
+      description: 'Allow reload'
+    }
+  },
+  run: () => {}
+})
+
+await cli(process.argv.slice(2), command, {
+  strict: true,
+  plugins: [suggestion()]
+})
+```
+
+If the user runs `app --alow-reload`, the validation output includes a hint:
+
+```txt
+Unknown option: --alow-reload
+Did you mean --allow-reload?
+```
+
+The same plugin also handles command suggestions:
+
+```txt
+Command not found: rn
+Did you mean run?
+```
+
+The plugin decorates validation error rendering. It does not detect unknown options or commands itself; Gunshi core provides structured validation errors and candidate metadata.
+
+You can combine it with the i18n plugin so the base validation message and suggestion hint use locale resources:
+
+```js
+import i18n from '@gunshi/plugin-i18n'
+import { suggestion } from '@gunshi/plugin-suggestion'
+
+await cli(process.argv.slice(2), command, {
+  strict: true,
+  plugins: [i18n({ locale: 'ja-JP' }), suggestion()]
+})
+```
+
 ### Shell Completion
 
 Enable tab completion across different shells:

--- a/packages/docs/src/guide/plugin/list.md
+++ b/packages/docs/src/guide/plugin/list.md
@@ -24,6 +24,10 @@ Provides shell completion functionality for bash, zsh, and fish.
 
 Adds a `--dry-run` option and helpers for printing planned side-effect operations without executing them.
 
+### [@gunshi/plugin-suggestion](https://github.com/kazupon/gunshi/tree/main/packages/plugin-suggestion)
+
+Adds Levenshtein-based suggestions for unknown long options and unknown commands.
+
 ## Community Plugins
 
 <!-- eslint-disable markdown/no-missing-label-refs -->

--- a/packages/gunshi/src/cli.test.ts
+++ b/packages/gunshi/src/cli.test.ts
@@ -1879,12 +1879,37 @@ describe('command lifecycle hooks', () => {
       const utils = await import('./utils.ts')
       const log = defineMockLog(utils)
       const mockCommand = vi.fn<() => void>()
+      let capturedError: AggregateError | undefined
 
       await expect(
-        cli(['--alow-reload'], { run: mockCommand }, { strict: true })
+        cli(
+          ['--alow-reload'],
+          {
+            toKebab: true,
+            args: {
+              allowReload: {
+                type: 'boolean'
+              }
+            },
+            run: mockCommand
+          },
+          {
+            strict: true,
+            onErrorCommand: (_ctx, error) => {
+              capturedError = error as AggregateError
+            }
+          }
+        )
       ).rejects.toBeInstanceOf(AggregateError)
 
       expect(mockCommand).not.toHaveBeenCalled()
+      expect(
+        (capturedError?.errors[0] as { values: Record<string, unknown> } | undefined)?.values
+      ).toEqual({
+        rawName: '--alow-reload',
+        name: 'alow-reload',
+        candidates: ['--help', '--version', '--allow-reload']
+      })
       expect(log()).toBe('Unknown option: --alow-reload')
     })
 

--- a/packages/gunshi/src/cli/core.ts
+++ b/packages/gunshi/src/cli/core.ts
@@ -205,6 +205,7 @@ function resolveArguments<G extends GunshiParamsConstraint>(
 type UnknownOption = {
   rawName: string
   name: string
+  candidates: readonly string[]
 }
 
 type StrictOptionValidationOptions = {
@@ -221,6 +222,17 @@ function findUnknownOptions(
   const knownLongOptions = new Set<string>()
   const knownShortOptions = new Set<string>()
   const knownNegatableOptions = new Set<string>()
+  const knownLongOptionCandidates = new Set<string>()
+  const longOptionCandidates: string[] = []
+
+  function addLongOptionCandidate(name: string): void {
+    const candidate = `--${name}`
+    if (knownLongOptionCandidates.has(candidate)) {
+      return
+    }
+    knownLongOptionCandidates.add(candidate)
+    longOptionCandidates.push(candidate)
+  }
 
   for (const [name, schema] of Object.entries(args)) {
     if (schema.type === 'positional') {
@@ -229,13 +241,16 @@ function findUnknownOptions(
 
     const optionName = resolveOptionName(name, schema, options)
     knownLongOptions.add(optionName)
+    addLongOptionCandidate(optionName)
 
     if (schema.short) {
       knownShortOptions.add(schema.short)
     }
 
     if (schema.type === 'boolean' && schema.negatable) {
-      knownNegatableOptions.add(`${NEGATABLE_OPTION_PREFIX}${optionName}`)
+      const negatableOptionName = `${NEGATABLE_OPTION_PREFIX}${optionName}`
+      knownNegatableOptions.add(negatableOptionName)
+      addLongOptionCandidate(negatableOptionName)
     }
   }
 
@@ -260,7 +275,8 @@ function findUnknownOptions(
 
     unknownOptions.push({
       rawName: token.rawName,
-      name: token.name
+      name: token.name,
+      candidates: isLongOption ? longOptionCandidates : []
     })
   }
 
@@ -276,12 +292,13 @@ function resolveOptionName(
 }
 
 function createUnknownOptionErrors(unknownOptions: UnknownOption[]): ArgsValidationError[] {
-  return unknownOptions.map(({ rawName, name }) => {
+  return unknownOptions.map(({ rawName, name, candidates }) => {
     return new ArgsValidationError(`Unknown option: ${rawName}`, {
       code: ArgsValidationErrorKeys.unknownOption,
       values: {
         rawName,
-        name
+        name,
+        candidates
       }
     })
   })

--- a/packages/plugin-i18n/src/index.test.ts
+++ b/packages/plugin-i18n/src/index.test.ts
@@ -71,6 +71,11 @@ describe('extension: translate', () => {
           displayName: "'--id'"
         })
       ).toEqual("Optional argument '--id' is required")
+      expect(
+        extension.translate('err:suggestion:did-you-mean', {
+          name: '--allow-reload'
+        })
+      ).toEqual('Did you mean --allow-reload?')
     })
 
     test('custom locale: ja-JP', async () => {
@@ -99,6 +104,11 @@ describe('extension: translate', () => {
           displayName: "'--id'"
         })
       ).toEqual("オプション '--id' は必須です")
+      expect(
+        extension.translate('err:suggestion:did-you-mean', {
+          name: '--allow-reload'
+        })
+      ).toEqual('--allow-reload の指定ミスではありませんか？')
     })
 
     test('custom builtinResources can override args validation error keys', async () => {

--- a/packages/plugin-suggestion/CHANGELOG.md
+++ b/packages/plugin-suggestion/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @gunshi/plugin-suggestion

--- a/packages/plugin-suggestion/LICENSE
+++ b/packages/plugin-suggestion/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 kazuya kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/plugin-suggestion/README.md
+++ b/packages/plugin-suggestion/README.md
@@ -1,0 +1,93 @@
+# @gunshi/plugin-suggestion
+
+Suggestion plugin for Gunshi.
+
+This plugin adds a short hint to validation errors when a user enters an unknown long option or an unknown command.
+It uses Levenshtein distance by default and works with Gunshi's structured validation errors.
+
+## Installation
+
+```sh
+npm install @gunshi/plugin-suggestion
+```
+
+## Usage
+
+```ts
+import { cli, define } from 'gunshi'
+import { suggestion } from '@gunshi/plugin-suggestion'
+
+const command = define({
+  name: 'app',
+  toKebab: true,
+  args: {
+    allowReload: {
+      type: 'boolean',
+      description: 'Allow reload'
+    }
+  },
+  run: () => {}
+})
+
+await cli(process.argv.slice(2), command, {
+  strict: true,
+  plugins: [suggestion()]
+})
+```
+
+When the user enters an unknown long option, the validation message includes a hint:
+
+```txt
+Unknown option: --alow-reload
+Did you mean --allow-reload?
+```
+
+When the user enters an unknown command, the plugin suggests a command from the same command level:
+
+```txt
+Command not found: rn
+Did you mean run?
+```
+
+## Options
+
+```ts
+suggestion({
+  maxDistance: 2,
+  maxSuggestions: 1,
+  includeOptions: true,
+  includeCommands: true,
+  distance: customDistance,
+  normalize: value => value.toLowerCase()
+})
+```
+
+- `maxDistance`: maximum distance allowed for a candidate.
+- `maxSuggestions`: maximum number of suggestions per validation error.
+- `includeOptions`: enables unknown long option suggestions.
+- `includeCommands`: enables command not found suggestions.
+- `distance`: custom distance function. Lower values are better matches.
+- `normalize`: normalizes typed input and candidates before scoring.
+
+## Internationalization
+
+The plugin can be combined with `@gunshi/plugin-i18n`.
+The suggestion hint uses the built-in resource key `err:suggestion:did-you-mean`.
+
+```ts
+import i18n from '@gunshi/plugin-i18n'
+import { suggestion } from '@gunshi/plugin-suggestion'
+
+await cli(argv, command, {
+  strict: true,
+  plugins: [i18n({ locale: 'ja-JP' }), suggestion()]
+})
+```
+
+Without i18n, the plugin falls back to `Did you mean {$name}?`.
+
+## Design notes
+
+The plugin does not detect unknown options or unknown commands by itself.
+Gunshi core creates structured validation errors and provides candidate metadata.
+This plugin only decorates validation error rendering and appends suggestion hints.

--- a/packages/plugin-suggestion/jsr.json
+++ b/packages/plugin-suggestion/jsr.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://jsr.io/schema/config-file.v1.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "name": "@gunshi/plugin-suggestion",
+  "description": "suggestion plugin for gunshi",
+  "version": "0.35.1",
+  "license": "MIT",
+  "publish": {
+    "include": ["src/**/*.ts", "package.json", "jsr.json", "README.md", "CHANGELOG.md", "LICENSE"],
+    "exclude": [
+      "src/**/*.test.ts",
+      "src/**/*.test-d.ts",
+      "**/__snapshots__/**",
+      "**/lib/**",
+      "**/dist/**"
+    ]
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/plugin-suggestion/package.json
+++ b/packages/plugin-suggestion/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@gunshi/plugin-suggestion",
+  "description": "suggestion plugin for gunshi",
+  "version": "0.35.1",
+  "author": {
+    "name": "kazuya kawaguchi",
+    "email": "kawakazu80@gmail.com"
+  },
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/kazupon",
+  "bugs": {
+    "url": "https://github.com/kazupon/gunshi/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kazupon/gunshi.git",
+    "directory": "packages/plugin-suggestion"
+  },
+  "keywords": [
+    "gunshi",
+    "suggestion",
+    "plugin",
+    "cli"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">= 22"
+  },
+  "type": "module",
+  "files": [
+    "lib"
+  ],
+  "module": "lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./lib/*",
+        "./*"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "build:docs": "tsx ../../scripts/api-references.ts",
+    "lint:jsr": "jsr publish --dry-run --allow-dirty",
+    "prepack": "pnpm build",
+    "typecheck:deno": "deno check --import-map=../../importmap.json ./src"
+  },
+  "dependencies": {
+    "@gunshi/plugin": "workspace:*"
+  },
+  "peerDependencies": {
+    "@gunshi/plugin-i18n": "workspace:*"
+  },
+  "devDependencies": {
+    "@gunshi/plugin-i18n": "workspace:*",
+    "@gunshi/resources": "workspace:*",
+    "deno": "catalog:",
+    "gunshi": "workspace:*",
+    "jsr": "catalog:",
+    "jsr-exports-lint": "catalog:",
+    "publint": "catalog:",
+    "tsdown": "catalog:"
+  }
+}

--- a/packages/plugin-suggestion/src/index.test-d.ts
+++ b/packages/plugin-suggestion/src/index.test-d.ts
@@ -1,0 +1,55 @@
+import { expectTypeOf, test } from 'vitest'
+import {
+  SuggestionErrorKeys,
+  defineSuggestNames,
+  levenshtein,
+  pluginId,
+  suggestion
+} from './index.ts'
+
+import type {
+  DistanceFunction,
+  ResolvedSuggestionOptions,
+  SuggestNames,
+  SuggestionErrorCode,
+  SuggestionOptions
+} from './index.ts'
+
+test('exports plugin APIs', () => {
+  expectTypeOf(suggestion).toBeFunction()
+  expectTypeOf(pluginId).toEqualTypeOf<'g:suggestion'>()
+  expectTypeOf(SuggestionErrorKeys.didYouMean).toEqualTypeOf<'err:suggestion:did-you-mean'>()
+  expectTypeOf<SuggestionErrorCode>().toEqualTypeOf<
+    (typeof SuggestionErrorKeys)[keyof typeof SuggestionErrorKeys]
+  >()
+})
+
+test('exports suggestion utility APIs', () => {
+  expectTypeOf(levenshtein).toEqualTypeOf<DistanceFunction>()
+  expectTypeOf(defineSuggestNames).toBeFunction()
+  expectTypeOf<SuggestNames>().toEqualTypeOf<
+    (typed: string, candidates: readonly string[]) => string[]
+  >()
+})
+
+test('accepts suggestion options', () => {
+  const options: SuggestionOptions = {
+    maxDistance: 1,
+    maxSuggestions: 2,
+    includeOptions: true,
+    includeCommands: false,
+    distance: () => 0,
+    normalize: value => value.toLowerCase()
+  }
+
+  const resolved: ResolvedSuggestionOptions = {
+    maxDistance: options.maxDistance!,
+    maxSuggestions: options.maxSuggestions!,
+    includeOptions: options.includeOptions!,
+    includeCommands: options.includeCommands!,
+    distance: options.distance!,
+    normalize: options.normalize!
+  }
+
+  expectTypeOf(defineSuggestNames(resolved)).toEqualTypeOf<SuggestNames>()
+})

--- a/packages/plugin-suggestion/src/index.test.ts
+++ b/packages/plugin-suggestion/src/index.test.ts
@@ -1,0 +1,341 @@
+import i18n from '@gunshi/plugin-i18n'
+import jaJPResource from '@gunshi/resources/ja-JP' with { type: 'json' }
+import { cli, define, lazy } from 'gunshi'
+import { describe, expect, test, vi } from 'vitest'
+import { defineMockLog } from '../../gunshi/test/utils.ts'
+import { defineSuggestNames, levenshtein, suggestion } from './index.ts'
+
+import type { ResolvedSuggestionOptions } from './index.ts'
+
+const defaultSuggestOptions: ResolvedSuggestionOptions = {
+  maxDistance: 2,
+  maxSuggestions: 1,
+  includeOptions: true,
+  includeCommands: true,
+  distance: levenshtein,
+  normalize: value => value
+}
+
+describe('levenshtein', () => {
+  test('calculates edit distance', () => {
+    expect(levenshtein('alow-reload', 'allow-reload')).toBe(1)
+    expect(levenshtein('same', 'same')).toBe(0)
+    expect(levenshtein('abc', 'abxc')).toBe(1)
+    expect(levenshtein('abcd', 'acd')).toBe(1)
+    expect(levenshtein('abcd', 'abxd')).toBe(1)
+  })
+})
+
+describe('defineSuggestNames', () => {
+  test('returns suggestions within threshold', () => {
+    const suggestNames = defineSuggestNames(defaultSuggestOptions)
+
+    expect(suggestNames('alow-reload', ['--allow-reload', '--clear-cache'])).toEqual([
+      '--allow-reload'
+    ])
+  })
+
+  test('excludes candidates beyond threshold', () => {
+    const suggestNames = defineSuggestNames({
+      ...defaultSuggestOptions,
+      maxDistance: 1
+    })
+
+    expect(suggestNames('reload', ['--clear-cache'])).toEqual([])
+  })
+
+  test('limits max suggestions and keeps definition order for ties', () => {
+    const suggestNames = defineSuggestNames({
+      ...defaultSuggestOptions,
+      maxSuggestions: 2
+    })
+
+    expect(suggestNames('ab', ['aa', 'ac', 'zz'])).toEqual(['aa', 'ac'])
+  })
+
+  test('uses custom distance and normalize functions', () => {
+    const distance = vi.fn<(input: string, candidate: string) => number>(() => 0)
+    const normalize = vi.fn<(value: string) => string>(value => value.toLowerCase())
+    const suggestNames = defineSuggestNames({
+      ...defaultSuggestOptions,
+      distance,
+      normalize
+    })
+
+    expect(suggestNames('ALLOW-RELOAD', ['--allow-reload'])).toEqual(['--allow-reload'])
+    expect(distance).toHaveBeenCalledWith('allow-reload', 'allow-reload')
+    expect(normalize).toHaveBeenCalled()
+  })
+})
+
+describe('suggestion plugin', () => {
+  test('suggests a known long option for an unknown option', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+    const run = vi.fn<() => void>()
+
+    await expect(
+      cli(
+        ['--alow-reload'],
+        define({
+          name: 'app',
+          toKebab: true,
+          args: {
+            allowReload: {
+              type: 'boolean'
+            }
+          },
+          run
+        }),
+        {
+          strict: true,
+          plugins: [suggestion()]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(run).not.toHaveBeenCalled()
+    expect(log()).toBe('Unknown option: --alow-reload\nDid you mean --allow-reload?')
+  })
+
+  test('does not suggest options when includeOptions is false', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        ['--alow-reload'],
+        define({
+          name: 'app',
+          toKebab: true,
+          args: {
+            allowReload: {
+              type: 'boolean'
+            }
+          },
+          run: () => {}
+        }),
+        {
+          strict: true,
+          plugins: [suggestion({ includeOptions: false })]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('Unknown option: --alow-reload')
+  })
+
+  test('does not suggest short options by default', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        ['-x'],
+        define({
+          name: 'app',
+          args: {
+            reload: {
+              type: 'boolean',
+              short: 'r'
+            }
+          },
+          run: () => {}
+        }),
+        {
+          strict: true,
+          plugins: [suggestion()]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('Unknown option: -x')
+  })
+
+  test('does not suggest unknown options when strict mode is disabled', async () => {
+    const run = vi.fn<() => void>()
+
+    await cli(
+      ['--alow-reload'],
+      define({
+        name: 'app',
+        toKebab: true,
+        args: {
+          allowReload: {
+            type: 'boolean'
+          }
+        },
+        run
+      }),
+      {
+        plugins: [suggestion()]
+      }
+    )
+
+    expect(run).toHaveBeenCalledOnce()
+  })
+
+  test('suggests a top-level command from same-level candidates', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+    const run = vi.fn<() => void>()
+
+    await expect(
+      cli(['rn'], define({ name: 'main', run }), {
+        subCommands: {
+          run: define({ name: 'run', run: vi.fn<() => void>() }),
+          init: define({ name: 'init', run: vi.fn<() => void>() })
+        },
+        plugins: [suggestion()]
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(run).not.toHaveBeenCalled()
+    expect(log()).toBe('Command not found: rn\nDid you mean run?')
+  })
+
+  test('uses nested command candidates from the parent command', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(['task', 'rn'], define({ name: 'main', run: () => {} }), {
+        subCommands: {
+          task: define({
+            name: 'task',
+            subCommands: {
+              run: define({ name: 'run', run: vi.fn<() => void>() }),
+              stop: define({ name: 'stop', run: vi.fn<() => void>() })
+            },
+            run: vi.fn<() => void>()
+          })
+        },
+        plugins: [suggestion()]
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('Command not found: rn\nDid you mean run?')
+  })
+
+  test('uses lazy parent command candidates', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(['task', 'rn'], define({ name: 'main', run: () => {} }), {
+        subCommands: {
+          task: lazy(
+            () =>
+              define({
+                name: 'task',
+                subCommands: {
+                  run: define({ name: 'run', run: vi.fn<() => void>() })
+                },
+                run: vi.fn<() => void>()
+              }),
+            {
+              name: 'task',
+              subCommands: {
+                run: define({ name: 'run', run: vi.fn<() => void>() })
+              }
+            }
+          )
+        },
+        plugins: [suggestion()]
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('Command not found: rn\nDid you mean run?')
+  })
+
+  test('does not suggest commands when includeCommands is false', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(['rn'], define({ name: 'main', run: () => {} }), {
+        subCommands: {
+          run: define({ name: 'run', run: vi.fn<() => void>() })
+        },
+        plugins: [suggestion({ includeCommands: false })]
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('Command not found: rn')
+  })
+
+  test('does not suggest commands when fallbackToEntry handles the input', async () => {
+    const run = vi.fn<() => void>()
+
+    await cli(['rn'], define({ name: 'main', run }), {
+      fallbackToEntry: true,
+      subCommands: {
+        run: define({ name: 'run', run: vi.fn<() => void>() })
+      },
+      plugins: [suggestion()]
+    })
+
+    expect(run).toHaveBeenCalledOnce()
+  })
+
+  test('localizes unknown option suggestion hints with i18n', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(
+        ['--alow-reload'],
+        define({
+          name: 'app',
+          toKebab: true,
+          args: {
+            allowReload: {
+              type: 'boolean'
+            }
+          },
+          run: () => {}
+        }),
+        {
+          strict: true,
+          plugins: [
+            i18n({
+              locale: 'ja-JP',
+              builtinResources: {
+                'ja-JP': jaJPResource
+              }
+            }),
+            suggestion()
+          ]
+        }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe(
+      '未定義のオプションです: --alow-reload\n--allow-reload の指定ミスではありませんか？'
+    )
+  })
+
+  test('localizes command suggestion hints with i18n', async () => {
+    const utils = await import('../../gunshi/src/utils.ts')
+    const log = defineMockLog(utils)
+
+    await expect(
+      cli(['rn'], define({ name: 'main', run: () => {} }), {
+        subCommands: {
+          run: define({ name: 'run', run: vi.fn<() => void>() })
+        },
+        plugins: [
+          i18n({
+            locale: 'ja-JP',
+            builtinResources: {
+              'ja-JP': jaJPResource
+            }
+          }),
+          suggestion()
+        ]
+      })
+    ).rejects.toBeInstanceOf(AggregateError)
+
+    expect(log()).toBe('コマンドが見つかりません: rn\nrun の指定ミスではありませんか？')
+  })
+})

--- a/packages/plugin-suggestion/src/index.ts
+++ b/packages/plugin-suggestion/src/index.ts
@@ -1,0 +1,349 @@
+/**
+ * The entry point of suggestion plugin.
+ *
+ * @example
+ * ```js
+ * import { cli } from 'gunshi'
+ * import { suggestion } from '@gunshi/plugin-suggestion'
+ *
+ * await cli(process.argv.slice(2), command, {
+ *   strict: true,
+ *   plugins: [
+ *     suggestion()
+ *   ]
+ * })
+ * ```
+ *
+ * @module
+ */
+
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import {
+  ArgsValidationErrorKeys,
+  isArgsValidationError,
+  isCommandNotFoundError,
+  plugin
+} from '@gunshi/plugin'
+
+import type { CommandContext, PluginWithoutExtension } from '@gunshi/plugin'
+
+/**
+ * The unique identifier for suggestion plugin.
+ */
+export const pluginId = 'g:suggestion' as const
+
+/**
+ * Type representing the unique identifier for suggestion plugin.
+ */
+export type PluginId = typeof pluginId
+
+/**
+ * Suggestion error resource keys.
+ */
+export const SuggestionErrorKeys = {
+  didYouMean: 'err:suggestion:did-you-mean'
+} as const
+
+/**
+ * Suggestion error resource key type.
+ */
+export type SuggestionErrorCode = (typeof SuggestionErrorKeys)[keyof typeof SuggestionErrorKeys]
+
+/**
+ * Distance function for scoring candidate names.
+ *
+ * Lower values are treated as better matches.
+ */
+export type DistanceFunction = (input: string, candidate: string) => number
+
+/**
+ * Suggestion function returned by {@link defineSuggestNames}.
+ */
+export type SuggestNames = (typed: string, candidates: readonly string[]) => string[]
+
+/**
+ * Suggestion plugin options.
+ */
+export interface SuggestionOptions {
+  /**
+   * Maximum distance allowed for a candidate.
+   *
+   * @default 2
+   */
+  maxDistance?: number
+  /**
+   * Maximum number of suggestions to render for one error.
+   *
+   * @default 1
+   */
+  maxSuggestions?: number
+  /**
+   * Whether to suggest known long options for unknown option errors.
+   *
+   * @default true
+   */
+  includeOptions?: boolean
+  /**
+   * Whether to suggest known commands for command-not-found errors.
+   *
+   * @default true
+   */
+  includeCommands?: boolean
+  /**
+   * Distance function used for ranking candidates.
+   *
+   * @default levenshtein
+   */
+  distance?: DistanceFunction
+  /**
+   * Normalize typed input and candidates before distance calculation.
+   *
+   * @default value => value
+   */
+  normalize?: (value: string) => string
+}
+
+/**
+ * Resolved suggestion plugin options.
+ */
+export interface ResolvedSuggestionOptions {
+  /**
+   * Maximum distance allowed for a candidate.
+   */
+  maxDistance: number
+  /**
+   * Maximum number of suggestions to render for one error.
+   */
+  maxSuggestions: number
+  /**
+   * Whether to suggest known long options for unknown option errors.
+   */
+  includeOptions: boolean
+  /**
+   * Whether to suggest known commands for command-not-found errors.
+   */
+  includeCommands: boolean
+  /**
+   * Distance function used for ranking candidates.
+   */
+  distance: DistanceFunction
+  /**
+   * Normalize typed input and candidates before distance calculation.
+   */
+  normalize: (value: string) => string
+}
+
+interface I18nLikeExtension {
+  translate?: (key: string, values?: Record<string, unknown>) => string
+}
+
+type UnknownOptionSuggestionValues = {
+  rawName?: unknown
+  name?: unknown
+  candidates?: unknown
+}
+
+const i18nPluginId = 'g:i18n' as const
+
+const dependencies = [{ id: i18nPluginId, optional: true }] as const
+
+/**
+ * Calculate the Levenshtein distance between two strings.
+ *
+ * @param input - Input string
+ * @param candidate - Candidate string
+ * @returns Edit distance between the two strings
+ */
+export function levenshtein(input: string, candidate: string): number {
+  if (input === candidate) {
+    return 0
+  }
+
+  if (input.length === 0) {
+    return candidate.length
+  }
+
+  if (candidate.length === 0) {
+    return input.length
+  }
+
+  let previous = Array.from({ length: candidate.length + 1 }, (_, index) => index)
+  let current = Array.from({ length: candidate.length + 1 }, () => 0)
+
+  for (let i = 1; i <= input.length; i++) {
+    current[0] = i
+    for (let j = 1; j <= candidate.length; j++) {
+      const cost = input[i - 1] === candidate[j - 1] ? 0 : 1
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost)
+    }
+    ;[previous, current] = [current, previous]
+  }
+
+  return previous[candidate.length]
+}
+
+/**
+ * Create a suggestion function with resolved options captured in a closure.
+ *
+ * @param options - Resolved suggestion options
+ * @returns A function that suggests candidate names
+ */
+export function defineSuggestNames(options: ResolvedSuggestionOptions): SuggestNames {
+  return function suggestNames(typed: string, candidates: readonly string[]): string[] {
+    const normalizedTyped = options.normalize(normalizeSuggestionName(typed))
+
+    return candidates
+      .map((candidate, index) => ({
+        candidate,
+        index,
+        distance: options.distance(
+          normalizedTyped,
+          options.normalize(normalizeSuggestionName(candidate))
+        )
+      }))
+      .filter(item => item.distance <= options.maxDistance)
+      .sort((a, b) => a.distance - b.distance || a.index - b.index)
+      .slice(0, options.maxSuggestions)
+      .map(item => item.candidate)
+  }
+}
+
+/**
+ * Suggestion plugin.
+ *
+ * @param options - Suggestion plugin options
+ * @returns A defined plugin as suggestion
+ */
+export function suggestion(options: SuggestionOptions = {}): PluginWithoutExtension {
+  const resolved = resolveSuggestionOptions(options)
+  const suggestNames = defineSuggestNames(resolved)
+
+  return plugin<
+    Record<typeof i18nPluginId, I18nLikeExtension>,
+    typeof pluginId,
+    typeof dependencies
+  >({
+    id: pluginId,
+    name: 'suggestion',
+    dependencies,
+
+    setup(ctx) {
+      ctx.decorateValidationErrorsRenderer(async (baseRenderer, cmdCtx, error) => {
+        const message = await baseRenderer(cmdCtx, error)
+        const hints: string[] = []
+        const seen = new Set<string>()
+
+        for (const err of error.errors as unknown[]) {
+          if (resolved.includeOptions) {
+            await collectSuggestions(
+              hints,
+              seen,
+              cmdCtx,
+              getUnknownOptionSuggestionInput(err),
+              suggestNames
+            )
+          }
+
+          if (resolved.includeCommands) {
+            await collectSuggestions(
+              hints,
+              seen,
+              cmdCtx,
+              getCommandSuggestionInput(err),
+              suggestNames
+            )
+          }
+        }
+
+        return [message, ...hints].filter(Boolean).join('\n')
+      })
+    }
+  })
+}
+
+function resolveSuggestionOptions(options: SuggestionOptions): ResolvedSuggestionOptions {
+  return {
+    maxDistance: options.maxDistance ?? 2,
+    maxSuggestions: options.maxSuggestions ?? 1,
+    includeOptions: options.includeOptions ?? true,
+    includeCommands: options.includeCommands ?? true,
+    distance: options.distance ?? levenshtein,
+    normalize: options.normalize ?? (value => value)
+  }
+}
+
+async function collectSuggestions(
+  hints: string[],
+  seen: Set<string>,
+  ctx: Readonly<CommandContext>,
+  input: { name: string; candidates: readonly string[] } | undefined,
+  suggestNames: SuggestNames
+): Promise<void> {
+  if (!input) {
+    return
+  }
+
+  const suggestions = suggestNames(input.name, input.candidates)
+  for (const name of suggestions) {
+    const hint = localizeSuggestion(ctx, name)
+    if (!seen.has(hint)) {
+      seen.add(hint)
+      hints.push(hint)
+    }
+  }
+}
+
+function getUnknownOptionSuggestionInput(
+  error: unknown
+): { name: string; candidates: readonly string[] } | undefined {
+  if (!isArgsValidationError(error) || error.code !== ArgsValidationErrorKeys.unknownOption) {
+    return undefined
+  }
+
+  const values = error.values as UnknownOptionSuggestionValues
+  if (typeof values.rawName !== 'string' || !values.rawName.startsWith('--')) {
+    return undefined
+  }
+  if (typeof values.name !== 'string' || !Array.isArray(values.candidates)) {
+    return undefined
+  }
+
+  const candidates = values.candidates.filter((candidate): candidate is string => {
+    return typeof candidate === 'string' && candidate.startsWith('--')
+  })
+
+  return candidates.length > 0
+    ? {
+        name: values.name,
+        candidates
+      }
+    : undefined
+}
+
+function getCommandSuggestionInput(
+  error: unknown
+): { name: string; candidates: readonly string[] } | undefined {
+  if (!isCommandNotFoundError(error) || error.candidates.length === 0) {
+    return undefined
+  }
+
+  return {
+    name: error.commandName,
+    candidates: error.candidates
+  }
+}
+
+function localizeSuggestion(ctx: Readonly<CommandContext>, name: string): string {
+  const i18n = (ctx.extensions as Record<string, I18nLikeExtension> | undefined)?.[i18nPluginId]
+  const translated = i18n?.translate?.(SuggestionErrorKeys.didYouMean, { name })
+
+  return translated || `Did you mean ${name}?`
+}
+
+function normalizeSuggestionName(value: string): string {
+  return value.startsWith('--') ? value.slice(2) : value
+}

--- a/packages/plugin-suggestion/tsdown.config.ts
+++ b/packages/plugin-suggestion/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { lintJsrExports } from 'jsr-exports-lint/tsdown'
+import { defineConfig } from 'tsdown'
+
+import type { UserConfig } from 'tsdown'
+
+const config: UserConfig = defineConfig({
+  entry: ['./src/index.ts'],
+  outDir: 'lib',
+  clean: true,
+  publint: true,
+  dts: true,
+  fixedExtension: false,
+  external: ['@gunshi/plugin'],
+  hooks: {
+    'build:done': lintJsrExports()
+  }
+})
+
+export default config

--- a/packages/resources/locales/en-US.json
+++ b/packages/resources/locales/en-US.json
@@ -18,5 +18,6 @@
   "err:arg:invalid-choice": "Invalid value for {$displayName}: expected one of {$choices}",
   "err:arg:custom-parse": "Invalid value for {$displayName}: {$reason}",
   "err:arg:unknown-option": "Unknown option: {$rawName}",
-  "err:cmd:not-found": "Command not found: {$commandName}"
+  "err:cmd:not-found": "Command not found: {$commandName}",
+  "err:suggestion:did-you-mean": "Did you mean {$name}?"
 }

--- a/packages/resources/locales/ja-JP.json
+++ b/packages/resources/locales/ja-JP.json
@@ -18,5 +18,6 @@
   "err:arg:invalid-choice": "{$displayName} の値が不正です。指定可能な値: {$choices}",
   "err:arg:custom-parse": "{$displayName} の値が不正です: {$reason}",
   "err:arg:unknown-option": "未定義のオプションです: {$rawName}",
-  "err:cmd:not-found": "コマンドが見つかりません: {$commandName}"
+  "err:cmd:not-found": "コマンドが見つかりません: {$commandName}",
+  "err:suggestion:did-you-mean": "{$name} の指定ミスではありませんか？"
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -71,3 +71,5 @@ export const ARG_ERROR_RESOURCE_KEYS = [
 ] as const
 
 export const COMMAND_ERROR_RESOURCE_KEYS = ['err:cmd:not-found'] as const
+
+export const SUGGESTION_ERROR_RESOURCE_KEYS = ['err:suggestion:did-you-mean'] as const

--- a/packages/shared/src/types.test-d.ts
+++ b/packages/shared/src/types.test-d.ts
@@ -2,9 +2,9 @@ import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import type { Args } from 'gunshi'
 import type {
-  ArgErrorResourceKeys,
   CommandArgKeys,
   CommandBuiltinKeys,
+  ErrorResourceKeys,
   ResolveTranslationKeys,
   Translation
 } from './types.ts'
@@ -50,7 +50,7 @@ describe('ResolveTranslationKeys', () => {
     } satisfies Args
 
     expectTypeOf<ResolveTranslationKeys<typeof _args>>().toEqualTypeOf<
-      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ArgErrorResourceKeys | CommandBuiltinKeys
+      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ErrorResourceKeys | CommandBuiltinKeys
     >()
   })
 
@@ -73,11 +73,7 @@ describe('ResolveTranslationKeys', () => {
     } as const
 
     expectTypeOf<ResolveTranslationKeys<typeof _args, typeof _ctx>>().toEqualTypeOf<
-      | 'test:arg:foo'
-      | 'test:arg:bar'
-      | 'test:arg:no-bar'
-      | ArgErrorResourceKeys
-      | CommandBuiltinKeys
+      'test:arg:foo' | 'test:arg:bar' | 'test:arg:no-bar' | ErrorResourceKeys | CommandBuiltinKeys
     >()
   })
 
@@ -98,7 +94,7 @@ describe('ResolveTranslationKeys', () => {
     const _ctx = {} as const
 
     expectTypeOf<ResolveTranslationKeys<typeof _args, typeof _ctx>>().toEqualTypeOf<
-      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ArgErrorResourceKeys | CommandBuiltinKeys
+      'arg:foo' | 'arg:bar' | 'arg:no-bar' | ErrorResourceKeys | CommandBuiltinKeys
     >()
   })
 
@@ -130,7 +126,7 @@ describe('ResolveTranslationKeys', () => {
       | 'test:arg:foo'
       | 'test:arg:bar'
       | 'test:arg:no-bar'
-      | ArgErrorResourceKeys
+      | ErrorResourceKeys
       | CommandBuiltinKeys
       | 'test:customResource'
     >()

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -10,7 +10,8 @@ import {
   BUILT_IN_PREFIX,
   COMMAND_ERROR_RESOURCE_KEYS,
   COMMAND_BUILTIN_RESOURCE_KEYS,
-  COMMON_ARGS
+  COMMON_ARGS,
+  SUGGESTION_ERROR_RESOURCE_KEYS
 } from './constants.ts'
 
 import type { Args } from 'gunshi'
@@ -79,11 +80,23 @@ export type ArgErrorResourceKeys = (typeof ARG_ERROR_RESOURCE_KEYS)[number]
 export type CommandErrorResourceKeys = (typeof COMMAND_ERROR_RESOURCE_KEYS)[number]
 
 /**
+ * Suggestion error resource keys.
+ */
+export type SuggestionErrorResourceKeys = (typeof SUGGESTION_ERROR_RESOURCE_KEYS)[number]
+
+/**
+ * Error resource keys.
+ */
+export type ErrorResourceKeys =
+  | ArgErrorResourceKeys
+  | CommandErrorResourceKeys
+  | SuggestionErrorResourceKeys
+
+/**
  * Built-in resource keys.
  */
 export type BuiltinResourceKeys =
-  | ArgErrorResourceKeys
-  | CommandErrorResourceKeys
+  | ErrorResourceKeys
   | CommandBuiltinArgsKeys
   | CommandBuiltinResourceKeys
 
@@ -126,7 +139,7 @@ export type ResolveTranslationKeys<
       : R
     : R | CommandBuiltinKeys,
   O = CommandArgKeys<A, C>
-> = ArgErrorResourceKeys | CommandBuiltinKeys | O | T
+> = ErrorResourceKeys | CommandBuiltinKeys | O | T
 
 /**
  * Translation function interface

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,37 @@ importers:
         specifier: 'catalog:'
         version: 0.21.0(@typescript/native-preview@7.0.0-dev.20260624.1)(oxc-resolver@11.20.0)(publint@0.3.21)(synckit@0.11.13)(typescript@6.0.3)
 
+  packages/plugin-suggestion:
+    dependencies:
+      '@gunshi/plugin':
+        specifier: workspace:*
+        version: link:../plugin
+    devDependencies:
+      '@gunshi/plugin-i18n':
+        specifier: workspace:*
+        version: link:../plugin-i18n
+      '@gunshi/resources':
+        specifier: workspace:*
+        version: link:../resources
+      deno:
+        specifier: 'catalog:'
+        version: 2.8.2
+      gunshi:
+        specifier: workspace:*
+        version: link:../gunshi
+      jsr:
+        specifier: 'catalog:'
+        version: 0.14.3
+      jsr-exports-lint:
+        specifier: 'catalog:'
+        version: 0.4.2(tsdown@0.21.0(@typescript/native-preview@7.0.0-dev.20260624.1)(oxc-resolver@11.20.0)(publint@0.3.21)(synckit@0.11.13)(typescript@6.0.3))
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.0(@typescript/native-preview@7.0.0-dev.20260624.1)(oxc-resolver@11.20.0)(publint@0.3.21)(synckit@0.11.13)(typescript@6.0.3)
+
   packages/resources:
     devDependencies:
       '@types/node':
@@ -5308,6 +5339,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5751,7 +5789,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.3':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,8 @@
       "@gunshi/plugin-renderer": ["./packages/plugin-renderer/src/index.ts"],
       "@gunshi/plugin-completion": ["./packages/plugin-completion/src/index.ts"],
       "@gunshi/plugin-i18n": ["./packages/plugin-i18n/src/index.ts"],
-      "@gunshi/plugin-global": ["./packages/plugin-global/src/index.ts"]
+      "@gunshi/plugin-global": ["./packages/plugin-global/src/index.ts"],
+      "@gunshi/plugin-suggestion": ["./packages/plugin-suggestion/src/index.ts"]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
Summary

Adds @gunshi/plugin-suggestion, an optional plugin that appends Levenshtein-based "Did you mean ...?" hints for unknown long options and command-not-found errors. The plugin resolves matching behavior once through defineSuggestNames, supports custom distance and normalization settings, and composes with plugin-i18n through err:suggestion:did-you-mean.

Core unknown-option errors now expose candidate names for plugins, and docs, resources, and tests cover option, command, nested command, lazy command, and i18n behavior.

Validation

pnpm build
pnpm build:docs
pnpm test
pnpm lint
typos .
