### PR TITLE
feat(docs): add 'Copy page as Markdown' action

### DIFF
--- a/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
+++ b/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
@@ -11,9 +11,11 @@ import {
 
 const route = useRoute()
 const isOpen = ref(false)
+const isCopying = ref(false)
 const copied = ref(false)
 const copyFailed = ref(false)
 const root = ref<HTMLElement>()
+const triggerButton = ref<HTMLButtonElement>()
 const disclosureId = 'copy-page-disclosure'
 
 const markdownPath = computed(() => resolveMarkdownPath(route.path))
@@ -27,8 +29,12 @@ function toggle() {
   isOpen.value = !isOpen.value
 }
 
-function close() {
+function close({ restoreFocus = false }: { restoreFocus?: boolean } = {}) {
   isOpen.value = false
+
+  if (restoreFocus) {
+    triggerButton.value?.focus()
+  }
 }
 
 function scheduleStatusReset() {
@@ -40,22 +46,29 @@ function scheduleStatusReset() {
 }
 
 async function copyPage() {
+  if (isCopying.value) {
+    return
+  }
+
+  isCopying.value = true
+
   try {
     await copyMarkdownPage(markdownPath.value)
     copied.value = true
     copyFailed.value = false
-    close()
+    close({ restoreFocus: true })
   } catch {
     copied.value = false
     copyFailed.value = true
   } finally {
+    isCopying.value = false
     scheduleStatusReset()
   }
 }
 
 function onKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {
-    close()
+    close({ restoreFocus: true })
   }
 }
 
@@ -63,7 +76,7 @@ function onDocumentPointerdown(event: PointerEvent) {
   const target = event.target
 
   if (target instanceof Node && !root.value?.contains(target)) {
-    close()
+    close({ restoreFocus: root.value?.contains(document.activeElement) })
   }
 }
 
@@ -89,6 +102,7 @@ onBeforeUnmount(() => {
 <template>
   <div ref="root" class="copy-page-action" @keydown="onKeydown">
     <button
+      ref="triggerButton"
       class="copy-page-button"
       type="button"
       :aria-expanded="isOpen"
@@ -110,14 +124,20 @@ onBeforeUnmount(() => {
     </button>
 
     <div v-if="isOpen" :id="disclosureId" class="copy-page-disclosure">
-      <button class="copy-page-item" type="button" @click="copyPage">
+      <button class="copy-page-item" type="button" :disabled="isCopying" @click="copyPage">
         <svg class="copy-page-item-icon" viewBox="0 0 16 16" aria-hidden="true">
           <path d="M6.2 9.8a3 3 0 0 1 0-4.2l2.6-2.7a3 3 0 0 1 4.3 4.3l-1.1 1.1" />
           <path d="M9.8 6.2a3 3 0 0 1 0 4.2l-2.6 2.7a3 3 0 0 1-4.3-4.3L4 7.7" />
         </svg>
-        <span>Copy Markdown page</span>
+        <span>{{ isCopying ? 'Copying Markdown page' : 'Copy Markdown page' }}</span>
       </button>
-      <a class="copy-page-item" :href="markdownPath" target="_blank" rel="noreferrer"  @click="close">
+      <a
+        class="copy-page-item"
+        :href="markdownPath"
+        target="_blank"
+        rel="noreferrer"
+        @click="close({ restoreFocus: true })"
+      >
         <svg class="copy-page-item-icon solid" viewBox="0 0 16 16" aria-hidden="true">
           <path d="M1.5 4A1.5 1.5 0 0 1 3 2.5h10A1.5 1.5 0 0 1 14.5 4v8A1.5 1.5 0 0 1 13 13.5H3A1.5 1.5 0 0 1 1.5 12V4Zm2 6.5h1.7V7.7l1.3 1.8 1.3-1.8v2.8h1.7v-5h-1.7L6.5 7.4 5.2 5.5H3.5v5Zm7-1.5H9.3l2 2 2-2H12V5.5h-1.5V9Z" />
         </svg>
@@ -127,7 +147,13 @@ onBeforeUnmount(() => {
           <path d="m5 11 7-7" />
         </svg>
       </a>
-      <a class="copy-page-item" :href="chatGptUrl" target="_blank" rel="noreferrer"  @click="close">
+      <a
+        class="copy-page-item"
+        :href="chatGptUrl"
+        target="_blank"
+        rel="noreferrer"
+        @click="close({ restoreFocus: true })"
+      >
         <svg class="copy-page-item-icon logo" viewBox="0 0 24 24" aria-hidden="true">
           <path
             d="M20.3 9.2a5.2 5.2 0 0 0-6.9-6.6A5.2 5.2 0 0 0 4.8 6a5.2 5.2 0 0 0-1.1 8.8 5.2 5.2 0 0 0 6.9 6.6 5.2 5.2 0 0 0 8.6-3.4 5.2 5.2 0 0 0 1.1-8.8Zm-8.9 10.5a3.8 3.8 0 0 1-4.2-1.1l.2-.1 4.9-2.8a.9.9 0 0 0 .4-.8V8.1l2.1 1.2v5.6a3.8 3.8 0 0 1-3.4 4.8Zm-6.5-6.1a3.8 3.8 0 0 1 1.2-4l.2.1 4.9 2.8a.9.9 0 0 0 .9 0l5.9-3.4v2.5l-4.8 2.8a3.8 3.8 0 0 1-8.3-.8Zm1.2-6.1a3.8 3.8 0 0 1 5.4-3.8v5.9L9.4 8.4 6.1 6.5Zm7.2 6.6-2.2-1.3v-2.6l2.2-1.3 2.2 1.3v2.6l-2.2 1.3Zm3.2-7.7-4.9-2.8h.1a3.8 3.8 0 0 1 5.2 2.4l-.2.1-4.9 2.8 2.1 1.2 2.6-1.5Zm2.5 3.9a3.8 3.8 0 0 1-1.2 4l-.2-.1-4.9-2.8v2.4l3.3 1.9a3.8 3.8 0 0 1 3-5.4Z"
@@ -139,7 +165,13 @@ onBeforeUnmount(() => {
           <path d="m5 11 7-7" />
         </svg>
       </a>
-      <a class="copy-page-item" :href="claudeUrl" target="_blank" rel="noreferrer"  @click="close">
+      <a
+        class="copy-page-item"
+        :href="claudeUrl"
+        target="_blank"
+        rel="noreferrer"
+        @click="close({ restoreFocus: true })"
+      >
         <svg class="copy-page-item-icon logo anthropic" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M16.8 4h-3.2l5.7 16h3.2L16.8 4Z" />
           <path d="M7.2 4 1.5 20h3.3l1.1-3.3h6.3l1.1 3.3h3.3L10.8 4H7.2Zm-.4 10 2.2-6.5 2.2 6.5H6.8Z" />

--- a/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
+++ b/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
@@ -110,9 +110,7 @@ onBeforeUnmount(() => {
       @click="toggle"
     >
       <svg class="copy-page-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
-        <path
-          d="M5.5 2.5h6a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2Z"
-        />
+        <path d="M5.5 2.5h6a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2Z" />
         <path d="M2.5 9.5v-7h7" />
       </svg>
       Copy page
@@ -139,7 +137,9 @@ onBeforeUnmount(() => {
         @click="close({ restoreFocus: true })"
       >
         <svg class="copy-page-item-icon solid" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M1.5 4A1.5 1.5 0 0 1 3 2.5h10A1.5 1.5 0 0 1 14.5 4v8A1.5 1.5 0 0 1 13 13.5H3A1.5 1.5 0 0 1 1.5 12V4Zm2 6.5h1.7V7.7l1.3 1.8 1.3-1.8v2.8h1.7v-5h-1.7L6.5 7.4 5.2 5.5H3.5v5Zm7-1.5H9.3l2 2 2-2H12V5.5h-1.5V9Z" />
+          <path
+            d="M1.5 4A1.5 1.5 0 0 1 3 2.5h10A1.5 1.5 0 0 1 14.5 4v8A1.5 1.5 0 0 1 13 13.5H3A1.5 1.5 0 0 1 1.5 12V4Zm2 6.5h1.7V7.7l1.3 1.8 1.3-1.8v2.8h1.7v-5h-1.7L6.5 7.4 5.2 5.5H3.5v5Zm7-1.5H9.3l2 2 2-2H12V5.5h-1.5V9Z"
+          />
         </svg>
         <span>View as Markdown</span>
         <svg class="copy-page-external" viewBox="0 0 16 16" aria-hidden="true">
@@ -174,7 +174,9 @@ onBeforeUnmount(() => {
       >
         <svg class="copy-page-item-icon logo anthropic" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M16.8 4h-3.2l5.7 16h3.2L16.8 4Z" />
-          <path d="M7.2 4 1.5 20h3.3l1.1-3.3h6.3l1.1 3.3h3.3L10.8 4H7.2Zm-.4 10 2.2-6.5 2.2 6.5H6.8Z" />
+          <path
+            d="M7.2 4 1.5 20h3.3l1.1-3.3h6.3l1.1 3.3h3.3L10.8 4H7.2Zm-.4 10 2.2-6.5 2.2 6.5H6.8Z"
+          />
         </svg>
         <span>Open in Claude</span>
         <svg class="copy-page-external" viewBox="0 0 16 16" aria-hidden="true">

--- a/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
+++ b/packages/docs/src/.vitepress/theme/components/CopyPageAction.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vitepress'
+import {
+  copyMarkdownPage,
+  createChatGptUrl,
+  createClaudeUrl,
+  resolveMarkdownPath,
+  resolvePublicMarkdownUrl
+} from '../copyPage'
+
+const route = useRoute()
+const isOpen = ref(false)
+const copied = ref(false)
+const copyFailed = ref(false)
+const root = ref<HTMLElement>()
+const disclosureId = 'copy-page-disclosure'
+
+const markdownPath = computed(() => resolveMarkdownPath(route.path))
+const publicMarkdownUrl = computed(() => resolvePublicMarkdownUrl(route.path))
+const chatGptUrl = computed(() => createChatGptUrl(publicMarkdownUrl.value))
+const claudeUrl = computed(() => createClaudeUrl(publicMarkdownUrl.value))
+
+let resetTimer: ReturnType<typeof setTimeout> | undefined
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+
+function close() {
+  isOpen.value = false
+}
+
+function scheduleStatusReset() {
+  clearTimeout(resetTimer)
+  resetTimer = setTimeout(() => {
+    copied.value = false
+    copyFailed.value = false
+  }, 2000)
+}
+
+async function copyPage() {
+  try {
+    await copyMarkdownPage(markdownPath.value)
+    copied.value = true
+    copyFailed.value = false
+    close()
+  } catch {
+    copied.value = false
+    copyFailed.value = true
+  } finally {
+    scheduleStatusReset()
+  }
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    close()
+  }
+}
+
+function onDocumentPointerdown(event: PointerEvent) {
+  const target = event.target
+
+  if (target instanceof Node && !root.value?.contains(target)) {
+    close()
+  }
+}
+
+watch(
+  () => route.path,
+  () => {
+    close()
+    copied.value = false
+    copyFailed.value = false
+  }
+)
+
+onMounted(() => {
+  document.addEventListener('pointerdown', onDocumentPointerdown)
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(resetTimer)
+  document.removeEventListener('pointerdown', onDocumentPointerdown)
+})
+</script>
+
+<template>
+  <div ref="root" class="copy-page-action" @keydown="onKeydown">
+    <button
+      class="copy-page-button"
+      type="button"
+      :aria-expanded="isOpen"
+      :aria-controls="disclosureId"
+      @click="toggle"
+    >
+      <svg class="copy-page-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
+        <path
+          d="M5.5 2.5h6a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2Z"
+        />
+        <path d="M2.5 9.5v-7h7" />
+      </svg>
+      Copy page
+      <span class="copy-page-chevron" aria-hidden="true">
+        <svg viewBox="0 0 16 16">
+          <path d="m4 6 4 4 4-4" />
+        </svg>
+      </span>
+    </button>
+
+    <div v-if="isOpen" :id="disclosureId" class="copy-page-disclosure">
+      <button class="copy-page-item" type="button" @click="copyPage">
+        <svg class="copy-page-item-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M6.2 9.8a3 3 0 0 1 0-4.2l2.6-2.7a3 3 0 0 1 4.3 4.3l-1.1 1.1" />
+          <path d="M9.8 6.2a3 3 0 0 1 0 4.2l-2.6 2.7a3 3 0 0 1-4.3-4.3L4 7.7" />
+        </svg>
+        <span>Copy Markdown page</span>
+      </button>
+      <a class="copy-page-item" :href="markdownPath" target="_blank" rel="noreferrer"  @click="close">
+        <svg class="copy-page-item-icon solid" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M1.5 4A1.5 1.5 0 0 1 3 2.5h10A1.5 1.5 0 0 1 14.5 4v8A1.5 1.5 0 0 1 13 13.5H3A1.5 1.5 0 0 1 1.5 12V4Zm2 6.5h1.7V7.7l1.3 1.8 1.3-1.8v2.8h1.7v-5h-1.7L6.5 7.4 5.2 5.5H3.5v5Zm7-1.5H9.3l2 2 2-2H12V5.5h-1.5V9Z" />
+        </svg>
+        <span>View as Markdown</span>
+        <svg class="copy-page-external" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M6 4h6v6" />
+          <path d="m5 11 7-7" />
+        </svg>
+      </a>
+      <a class="copy-page-item" :href="chatGptUrl" target="_blank" rel="noreferrer"  @click="close">
+        <svg class="copy-page-item-icon logo" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M20.3 9.2a5.2 5.2 0 0 0-6.9-6.6A5.2 5.2 0 0 0 4.8 6a5.2 5.2 0 0 0-1.1 8.8 5.2 5.2 0 0 0 6.9 6.6 5.2 5.2 0 0 0 8.6-3.4 5.2 5.2 0 0 0 1.1-8.8Zm-8.9 10.5a3.8 3.8 0 0 1-4.2-1.1l.2-.1 4.9-2.8a.9.9 0 0 0 .4-.8V8.1l2.1 1.2v5.6a3.8 3.8 0 0 1-3.4 4.8Zm-6.5-6.1a3.8 3.8 0 0 1 1.2-4l.2.1 4.9 2.8a.9.9 0 0 0 .9 0l5.9-3.4v2.5l-4.8 2.8a3.8 3.8 0 0 1-8.3-.8Zm1.2-6.1a3.8 3.8 0 0 1 5.4-3.8v5.9L9.4 8.4 6.1 6.5Zm7.2 6.6-2.2-1.3v-2.6l2.2-1.3 2.2 1.3v2.6l-2.2 1.3Zm3.2-7.7-4.9-2.8h.1a3.8 3.8 0 0 1 5.2 2.4l-.2.1-4.9 2.8 2.1 1.2 2.6-1.5Zm2.5 3.9a3.8 3.8 0 0 1-1.2 4l-.2-.1-4.9-2.8v2.4l3.3 1.9a3.8 3.8 0 0 1 3-5.4Z"
+          />
+        </svg>
+        <span>Open in ChatGPT</span>
+        <svg class="copy-page-external" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M6 4h6v6" />
+          <path d="m5 11 7-7" />
+        </svg>
+      </a>
+      <a class="copy-page-item" :href="claudeUrl" target="_blank" rel="noreferrer"  @click="close">
+        <svg class="copy-page-item-icon logo anthropic" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M16.8 4h-3.2l5.7 16h3.2L16.8 4Z" />
+          <path d="M7.2 4 1.5 20h3.3l1.1-3.3h6.3l1.1 3.3h3.3L10.8 4H7.2Zm-.4 10 2.2-6.5 2.2 6.5H6.8Z" />
+        </svg>
+        <span>Open in Claude</span>
+        <svg class="copy-page-external" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M6 4h6v6" />
+          <path d="m5 11 7-7" />
+        </svg>
+      </a>
+    </div>
+
+    <span v-if="copied" class="copy-page-status" aria-live="polite">Copied</span>
+    <span v-else-if="copyFailed" class="copy-page-status error" aria-live="polite">
+      Copy failed
+    </span>
+  </div>
+</template>

--- a/packages/docs/src/.vitepress/theme/copyPage.ts
+++ b/packages/docs/src/.vitepress/theme/copyPage.ts
@@ -34,17 +34,34 @@ export async function copyMarkdownPage(
   markdownPath: string,
   {
     fetcher = fetch,
-    clipboard = navigator.clipboard
+    clipboard = navigator.clipboard,
+    timeoutMs = 10_000
   }: {
     fetcher?: typeof fetch
     clipboard?: Pick<Clipboard, 'writeText'>
+    timeoutMs?: number
   } = {}
 ): Promise<void> {
-  const response = await fetcher(markdownPath)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch Markdown page: ${response.status} ${response.statusText}`)
+  try {
+    const response = await fetcher(markdownPath, { signal: controller.signal })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch Markdown page: ${response.status} ${response.statusText}`)
+    }
+
+    await clipboard.writeText(await response.text())
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Timed out fetching Markdown page after ${timeoutMs}ms`)
+    }
+
+    throw error
+  } finally {
+    clearTimeout(timeout)
   }
-
-  await clipboard.writeText(await response.text())
 }

--- a/packages/docs/src/.vitepress/theme/copyPage.ts
+++ b/packages/docs/src/.vitepress/theme/copyPage.ts
@@ -1,0 +1,50 @@
+const PUBLIC_DOCS_ORIGIN = 'https://gunshi.dev'
+
+export const chatGptPromptBaseUrl = 'https://chatgpt.com/?hints=search&prompt='
+export const claudePromptBaseUrl = 'https://claude.ai/new?q='
+
+export function resolveMarkdownPath(pathname: string): string {
+  const path = pathname.split(/[?#]/u)[0]?.replace(/\/+$/u, '') || '/'
+  const cleanPath = path.endsWith('.html') ? path.slice(0, -'.html'.length) : path
+
+  if (cleanPath === '/') {
+    return '/index.md'
+  }
+
+  return `${cleanPath}.md`
+}
+
+export function resolvePublicMarkdownUrl(pathname: string): string {
+  return `${PUBLIC_DOCS_ORIGIN}${resolveMarkdownPath(pathname)}`
+}
+
+export function createAiPrompt(markdownUrl: string): string {
+  return `Read from ${markdownUrl} so I can ask questions about this Gunshi documentation page.`
+}
+
+export function createChatGptUrl(markdownUrl: string): string {
+  return `${chatGptPromptBaseUrl}${encodeURIComponent(createAiPrompt(markdownUrl))}`
+}
+
+export function createClaudeUrl(markdownUrl: string): string {
+  return `${claudePromptBaseUrl}${encodeURIComponent(createAiPrompt(markdownUrl))}`
+}
+
+export async function copyMarkdownPage(
+  markdownPath: string,
+  {
+    fetcher = fetch,
+    clipboard = navigator.clipboard
+  }: {
+    fetcher?: typeof fetch
+    clipboard?: Pick<Clipboard, 'writeText'>
+  } = {}
+): Promise<void> {
+  const response = await fetcher(markdownPath)
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Markdown page: ${response.status} ${response.statusText}`)
+  }
+
+  await clipboard.writeText(await response.text())
+}

--- a/packages/docs/src/.vitepress/theme/copyPage.ts
+++ b/packages/docs/src/.vitepress/theme/copyPage.ts
@@ -1,7 +1,7 @@
 const PUBLIC_DOCS_ORIGIN = 'https://gunshi.dev'
 
-export const chatGptPromptBaseUrl = 'https://chatgpt.com/?hints=search&prompt='
-export const claudePromptBaseUrl = 'https://claude.ai/new?q='
+const chatGptPromptBaseUrl = 'https://chatgpt.com/?hints=search&prompt='
+const claudePromptBaseUrl = 'https://claude.ai/new?q='
 
 export function resolveMarkdownPath(pathname: string): string {
   const path = pathname.split(/[?#]/u)[0]?.replace(/\/+$/u, '') || '/'
@@ -18,7 +18,7 @@ export function resolvePublicMarkdownUrl(pathname: string): string {
   return `${PUBLIC_DOCS_ORIGIN}${resolveMarkdownPath(pathname)}`
 }
 
-export function createAiPrompt(markdownUrl: string): string {
+function createAiPrompt(markdownUrl: string): string {
   return `Read from ${markdownUrl} so I can ask questions about this Gunshi documentation page.`
 }
 

--- a/packages/docs/src/.vitepress/theme/custom.css
+++ b/packages/docs/src/.vitepress/theme/custom.css
@@ -30,3 +30,147 @@
   height: auto;
   max-width: 100%;
 }
+
+.copy-page-action {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 12px;
+  min-height: 32px;
+}
+
+.copy-page-button {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  padding: 0;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 32px;
+  overflow: hidden;
+  transition:
+    border-color 0.2s,
+    color 0.2s,
+    background-color 0.2s;
+}
+
+.copy-page-button:hover,
+.copy-page-button[aria-expanded='true'] {
+  border-color: var(--vp-c-brand-2);
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+}
+
+.copy-page-trigger-icon {
+  margin-left: 10px;
+  margin-right: 7px;
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.copy-page-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 10px;
+  border-left: 1px solid var(--vp-c-divider);
+  width: 34px;
+  align-self: stretch;
+}
+
+.copy-page-chevron svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.copy-page-disclosure {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  min-width: 216px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  padding: 6px;
+  background: var(--vp-c-bg);
+  box-shadow: var(--vp-shadow-2);
+}
+
+.copy-page-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  border-radius: 6px;
+  padding: 7px 8px;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.copy-page-item:hover,
+.copy-page-item:focus {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+}
+
+.copy-page-item-icon {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.copy-page-item-icon.solid,
+.copy-page-item-icon.logo {
+  fill: currentColor;
+  stroke: none;
+}
+
+.copy-page-item-icon.anthropic {
+  width: 19px;
+}
+
+.copy-page-external {
+  margin-left: -5px;
+  width: 12px;
+  height: 12px;
+  color: var(--vp-c-text-3);
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.copy-page-status {
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.copy-page-status.error {
+  color: var(--vp-c-danger-1);
+}

--- a/packages/docs/src/.vitepress/theme/custom.css
+++ b/packages/docs/src/.vitepress/theme/custom.css
@@ -132,6 +132,11 @@
   background: var(--vp-c-bg-soft);
 }
 
+.copy-page-item:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
 .copy-page-item-icon {
   flex: 0 0 auto;
   width: 18px;

--- a/packages/docs/src/.vitepress/theme/index.ts
+++ b/packages/docs/src/.vitepress/theme/index.ts
@@ -3,6 +3,8 @@ import Theme from 'vitepress/theme'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { defineAsyncComponent, h } from 'vue'
 // @ts-expect-error -- FIXME: missing types
+import CopyPageAction from './components/CopyPageAction.vue'
+// @ts-expect-error -- FIXME: missing types
 import HomeSponsors from './components/HomeSponsors.vue'
 import './custom.css'
 
@@ -10,6 +12,7 @@ export default {
   ...Theme,
   Layout() {
     return h(Theme.Layout, null, {
+      'doc-before': () => h(CopyPageAction),
       'home-features-after': () => h(HomeSponsors)
       // NOTE: Uncomment below to show a release banner
       // @ts-expect-error -- FIXME: missing types

--- a/packages/docs/test/copyPage.test.ts
+++ b/packages/docs/test/copyPage.test.ts
@@ -42,7 +42,10 @@ describe('copy page helpers', () => {
       fetcher
     })
 
-    expect(fetcher).toHaveBeenCalledWith('/guide/essentials/getting-started.md')
+    expect(fetcher).toHaveBeenCalledWith(
+      '/guide/essentials/getting-started.md',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
     expect(writeText).toHaveBeenCalledWith(markdown)
   })
 })

--- a/packages/docs/test/copyPage.test.ts
+++ b/packages/docs/test/copyPage.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  copyMarkdownPage,
+  createChatGptUrl,
+  createClaudeUrl,
+  resolveMarkdownPath,
+  resolvePublicMarkdownUrl
+} from '../src/.vitepress/theme/copyPage'
+
+describe('copy page helpers', () => {
+  test.each([
+    ['/', '/index.md'],
+    ['/guide/introduction/what-is-gunshi', '/guide/introduction/what-is-gunshi.md'],
+    ['/guide/introduction/what-is-gunshi.html', '/guide/introduction/what-is-gunshi.md'],
+    ['/api/', '/api.md'],
+    ['/release/v0.27?utm=docs', '/release/v0.27.md'],
+    ['/showcase#projects', '/showcase.md']
+  ])('resolves %s to the canonical Markdown path', (pathname, expected) => {
+    expect(resolveMarkdownPath(pathname)).toBe(expected)
+  })
+
+  test('uses the public docs origin for AI prompt URLs', () => {
+    const markdownUrl = resolvePublicMarkdownUrl('/guide/essentials/getting-started')
+
+    expect(markdownUrl).toBe('https://gunshi.dev/guide/essentials/getting-started.md')
+    expect(decodeURIComponent(createChatGptUrl(markdownUrl))).toContain(markdownUrl)
+    expect(decodeURIComponent(createClaudeUrl(markdownUrl))).toContain(markdownUrl)
+  })
+
+  test('fetches the canonical Markdown response and copies it unchanged', async () => {
+    const markdown = '# Getting Started\n\nUse Gunshi.'
+    const writeText = vi.fn<Clipboard['writeText']>().mockResolvedValue(undefined)
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(markdown, {
+        headers: { 'content-type': 'text/markdown' },
+        status: 200
+      })
+    )
+
+    await copyMarkdownPage('/guide/essentials/getting-started.md', {
+      clipboard: { writeText },
+      fetcher
+    })
+
+    expect(fetcher).toHaveBeenCalledWith('/guide/essentials/getting-started.md')
+    expect(writeText).toHaveBeenCalledWith(markdown)
+  })
+})

--- a/packages/docs/test/copyPage.test.ts
+++ b/packages/docs/test/copyPage.test.ts
@@ -48,4 +48,77 @@ describe('copy page helpers', () => {
     )
     expect(writeText).toHaveBeenCalledWith(markdown)
   })
+
+  test('throws when the Markdown response is not OK', async () => {
+    const writeText = vi.fn<Clipboard['writeText']>().mockResolvedValue(undefined)
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('Not found', {
+        status: 404,
+        statusText: 'Not Found'
+      })
+    )
+
+    await expect(
+      copyMarkdownPage('/guide/essentials/missing.md', {
+        clipboard: { writeText },
+        fetcher
+      })
+    ).rejects.toThrow('Failed to fetch Markdown page: 404 Not Found')
+
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  test('throws a timeout error when the Markdown request is aborted', async () => {
+    vi.useFakeTimers()
+
+    const writeText = vi.fn<Clipboard['writeText']>().mockResolvedValue(undefined)
+    const fetcher = vi.fn<typeof fetch>((_input, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            reject(new DOMException('Aborted', 'AbortError'))
+          },
+          { once: true }
+        )
+      })
+    })
+
+    try {
+      const copy = copyMarkdownPage('/guide/essentials/getting-started.md', {
+        clipboard: { writeText },
+        fetcher,
+        timeoutMs: 50
+      })
+      const assertion = expect(copy).rejects.toThrow('Timed out fetching Markdown page after 50ms')
+
+      await vi.advanceTimersByTimeAsync(50)
+
+      await assertion
+      expect(writeText).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('clears the timeout when fetching Markdown fails', async () => {
+    const error = new Error('Network unavailable')
+    const writeText = vi.fn<Clipboard['writeText']>().mockResolvedValue(undefined)
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const fetcher = vi.fn<typeof fetch>().mockRejectedValue(error)
+
+    try {
+      await expect(
+        copyMarkdownPage('/guide/essentials/getting-started.md', {
+          clipboard: { writeText },
+          fetcher
+        })
+      ).rejects.toThrow(error)
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+      expect(writeText).not.toHaveBeenCalled()
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add copy the current documentation page as Markdown so that I can easily share it with AI coding assistants, save notes, or reuse the documentation without manually selecting and formatting the content.

### Linked Issues

Fixes: #606 

### Additional context

<img width="1917" height="922" alt="image" src="https://github.com/user-attachments/assets/9ff39557-59ff-41d8-b284-49389922c8cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Copy page” dropdown to documentation pages to copy the current page as Markdown.
  * Added quick actions to view the page as Markdown and open it in ChatGPT or Claude in new tabs.
  * Includes “Copied”/“Copy failed” feedback with automatic reset and improved dropdown dismissal (including Escape/outside click).
* **Style**
  * Updated styling for the copy action UI, dropdown, icons, external link indicators, and error state.
* **Tests**
  * Added unit tests covering path/URL resolution, AI link generation, and the copy workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->