### PR TITLE
chore: bump args-tokens

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^25.6.2
       version: 25.9.2
     args-tokens:
-      specifier: ^0.28.1
-      version: 0.28.1
+      specifier: ^0.28.2
+      version: 0.28.2
     deno:
       specifier: ^2.7.14
       version: 2.8.2
@@ -247,7 +247,7 @@ importers:
         version: 14.3.0(vue@3.5.35(typescript@6.0.3))
       args-tokens:
         specifier: 'catalog:'
-        version: 0.28.1
+        version: 0.28.2
       mermaid:
         specifier: ^11.12.0
         version: 11.15.0
@@ -295,7 +295,7 @@ importers:
         version: link:../shared
       args-tokens:
         specifier: 'catalog:'
-        version: 0.28.1
+        version: 0.28.2
       deno:
         specifier: 'catalog:'
         version: 2.8.2
@@ -3007,8 +3007,8 @@ packages:
     resolution: {integrity: sha512-kWceoEa1zXbcBvgy+BT1ddTLyB7B51u32EhOK/ZMY324nxmQAm767HD+g+9avBEPVmoDjWIYLvsSCQqtbcph/g==}
     engines: {node: '>= 20'}
 
-  args-tokens@0.28.1:
-    resolution: {integrity: sha512-2L4pJA8XcdRCqkNb5budSdbifzFP0iXexM1rF27kKLp8tWYfzGDV6BaAeBmrU6YLKct3Gt6Kn0njlAogJAdI6w==}
+  args-tokens@0.28.2:
+    resolution: {integrity: sha512-8vwmYY0d34G+/6MdBDmL3oV1FdY8HApRz/EO0PpdjAn5mEFuV1Hsr5DVrDh9EnlGMBgdaBFN/WcyczLeCumydw==}
     engines: {node: '>= 22'}
 
   array-find-index@1.0.2:
@@ -6569,7 +6569,7 @@ snapshots:
 
   args-tokens@0.17.1: {}
 
-  args-tokens@0.28.1: {}
+  args-tokens@0.28.2: {}
 
   array-find-index@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   "@types/node": ^25.6.2
   vitepress-api-references: ^0.3.0
   tsx: ^4.21.0
-  args-tokens: ^0.28.1
+  args-tokens: ^0.28.2
 overrides:
   # Pin rolldown to 1.0.0 (GA). Without this, tsdown@0.21.0 resolves to
   # rolldown@1.0.0-rc.7, whose `@rolldown/binding-*` optional dependencies


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Bump `args-tokens` from `0.28.1` to `0.28.2`.

This is a patch release. The user-facing change is a combinators type fix so composing `required()` and `multiple()` preserves both modifiers:

- `required(multiple(string()))` infers `string[]` (was `string`)
- `multiple(required(string()))` infers `string[]` (was `string[] | undefined`)

Runtime behavior is unchanged. gunshi re-exports `args-tokens/combinators`, and types are inlined via `dts.resolve`, so the catalog and lockfile need this bump for published types to pick up the fix.

Release: https://github.com/kazupon/args-tokens/releases/tag/v0.28.2
Fix: https://github.com/kazupon/args-tokens/pull/593

Verified with `pnpm test:core` (270 tests passed).

### Linked Issues

### Additional context

Catalog update in `pnpm-workspace.yaml` (`^0.28.1` → `^0.28.2`) plus the matching `pnpm-lock.yaml` resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `args-tokens` package version to `^0.28.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->