### PR TITLE
refactor(release): generate changelog before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 # Triggered automatically by tag push (created via `pnpm release` → bumpp).
+# CHANGELOG.md is already part of the tagged release commit produced by
+# `pnpm release`. This workflow does not generate or commit the changelog.
 # Can also be re-run manually via `workflow_dispatch` for partial recovery
 # (e.g. retry only npm-publish after a transient failure).
 on:
@@ -172,12 +174,13 @@ jobs:
           done
 
   release-notes:
-    name: Create GitHub Release and sync changelog
+    name: Create GitHub Release
     needs: [npm-publish, jsr-publish]
     # Runs when:
     # - tag push and both publish jobs succeeded, OR
     # - workflow_dispatch with job=release-notes (publish jobs are skipped), OR
     # - workflow_dispatch with job=all and both publish jobs succeeded
+    # CHANGELOG.md is already in the tagged commit from `pnpm release`.
     if: >-
       always() && (
         (github.event_name == 'push' &&
@@ -190,35 +193,25 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write # GitHub Release 作成 + main への CHANGELOG push
+      contents: write # create GitHub Release
     steps:
-      - name: Checkout main
-        # zizmor: ignore[artipacked] needs persisted credentials so that
-        # stefanzweifel/git-auto-commit-action can push the changelog commit.
+      - name: Checkout tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ env.TAG }}
+          persist-credentials: false
 
       - name: Create GitHub Release
         # 既存 Release があれば skip (workflow_dispatch リトライ時の冪等性)。
         run: |
-          if gh release view "$TAG" > /dev/null 2>&1; then
+          if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping creation"
           else
-            gh release create "$TAG" --generate-notes
+            FLAGS=(--verify-tag --generate-notes)
+            if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+              FLAGS+=(--prerelease)
+            fi
+            gh release create "$TAG" "${FLAGS[@]}"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sync changelog from GitHub Releases
-        run: npx gh-changelogen --repo=kazupon/gunshi --tag="$TAG"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit changelog
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          branch: main
-          file_pattern: CHANGELOG.md
-          commit_message: 'chore: generate changelog'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ pnpm build:docs
 # Develop documentation site
 pnpm dev:docs
 
-# Release new version (bumps versions, creates tag, pushes)
+# Release new version (updates CHANGELOG.md, bumps versions, creates tag, pushes)
+# Requires GH_TOKEN with Contents: write, e.g. GH_TOKEN="$(gh auth token)" pnpm release
 pnpm release
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
     - [Work Step Example](#work-step-example)
   - [Development Setup](#development-setup)
     - [Commonly used NPM scripts](#commonly-used-npm-scripts)
+  - [Release](#release)
 
 ## Issue Reporting Guidelines
 
@@ -62,6 +63,20 @@ pnpm fix
 There are some other scripts available in the `scripts` section of the `package.json` file.
 
 **Please make sure to have this pass successfully before submitting a PR.** Although the lint will be run against your PR on the CI server, it is better to have it working locally beforehand.
+
+## Release
+
+Bump versions, write `CHANGELOG.md` from GitHub-generated notes, then commit, tag, and push. Run on a clean `main` whose `HEAD` is already on `origin`. Provide a token with Contents: write:
+
+```sh
+GH_TOKEN="$(gh auth token)" pnpm release
+```
+
+Do not leave unrelated tracked changes: bumpp commits every tracked dirty file (`all: true`). `CHANGELOG.md` must already be tracked. The future tag must not exist locally or remotely.
+
+`pnpm release` generates changelog notes for the current `HEAD` (the commit before the release commit). GitHub Actions then publishes npm/JSR from the tag and creates the GitHub Release. It does not rewrite or commit `CHANGELOG.md`.
+
+If GitHub Release creation fails after publish, re-run the Release workflow with `job=release-notes` and the existing tag. The `"changelog"` script (`gh-changelogen --repo=kazupon/gunshi`) is published-release mode for manual recovery and requires `--tag`.
 
 ## Notes
 

--- a/bump.config.test.ts
+++ b/bump.config.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import config from './bump.config.ts'
+
+test('bumpp config writes generated notes before the release commit', () => {
+  expect(config.files).toEqual(['package.json', 'packages/**/package.json', 'packages/**/jsr.json'])
+  expect(config.all).toBe(true)
+  expect(config.commit).toBe('release: v%s')
+  expect(config.tag).toBe(true)
+  expect(config.push).toBe(true)
+  expect(config.execute).toBeTypeOf('function')
+
+  const source = String(config.execute)
+  expect(source).toMatch(/source:\s*['"]generated-notes['"]/)
+  expect(source).toMatch(/targetCommitish:\s*['"]HEAD['"]/)
+  expect(source).toContain('updateChangelog')
+})

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'bumpp'
+import { updateChangelog } from 'gh-changelogen'
+
+export default defineConfig({
+  files: ['package.json', 'packages/**/package.json', 'packages/**/jsr.json'],
+  all: true,
+  commit: 'release: v%s',
+  tag: true,
+  push: true,
+  execute: async operation => {
+    await updateChangelog({
+      repository: 'kazupon/gunshi',
+      tagName: `v${operation.state.newVersion}`,
+      source: 'generated-notes',
+      targetCommitish: 'HEAD',
+      output: 'CHANGELOG.md'
+    })
+  }
+})

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,7 +3,7 @@ import type { KnipConfig } from 'knip'
 export default {
   workspaces: {
     '.': {
-      entry: ['scripts/*.ts'],
+      entry: ['scripts/*.ts', 'bump.config.ts'],
       project: '**/*.ts'
     },
     'packages/gunshi': {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lint:typecheck": "pnpm run \"/^typecheck:/\"",
     "prepare": "git config --local core.hooksPath .githooks && pnpm run gen:importmap",
     "preview:docs": "pnpm -F @gunshi/docs preview",
-    "release": "bumpp \"package.json\" \"packages/**/package.json\" \"packages/**/jsr.json\" --commit \"release: v\" --all --push --tag",
+    "release": "bumpp",
     "test": "vitest --typecheck run",
     "test:core": "vitest --typecheck run packages/gunshi",
     "test:plugin-completion": "vitest --typecheck run packages/plugin-completion",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Generate `CHANGELOG.md` during `pnpm release` (bumpp `execute` + gh-changelogen `generated-notes`) so the notes land in the same commit as the version bump, before tag/push.

CI `release-notes` now only creates the GitHub Release from the tag. It no longer runs `gh-changelogen` or commits changelog to `main`.

This matches args-tokens (#576). npm/JSR publish jobs are unchanged.

Release locally with:

```sh
GH_TOKEN="$(gh auth token)" pnpm release
```

### Linked Issues

### Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Releases now use the tagged commit’s changelog when creating GitHub Releases.
  * Support was added for creating prereleases through the release workflow.
  * Version updates, changelog generation, commits, tags, and publishing are coordinated through the configured release command.

* **Documentation**
  * Added contributor guidance for preparing and publishing releases, including required permissions and recovery steps.

* **Tests**
  * Added validation for release configuration and changelog generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->